### PR TITLE
Fix type/lint errors in scripts/generate.ts migrate integration

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -22,6 +22,10 @@ import migrate, { type default as Migrate } from '@oxlint/migrate';
 
 type OxlintConfig = Awaited<ReturnType<typeof Migrate>>;
 
+type MigrateInput = Parameters<typeof migrate>[0];
+type MigrateConfig = Awaited<MigrateInput> extends Array<infer C> ? C : Awaited<MigrateInput>;
+type MigrateRules = MigrateConfig extends { rules?: infer R } ? R : never;
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, '..');
 const configsDir = join(rootDir, 'configs');
@@ -418,15 +422,15 @@ for (const config of configs) {
 
   // Pass the flattened rules as a single ESLint flat config object.
   // migrate() returns an oxlint-compatible config with supported rules only.
-  const oxlintResult = await migrate(
-    { rules } as unknown as Parameters<typeof migrate>[0],
-    undefined,
-    {
-      reporter,
-      withNursery: true,
-      typeAware: true,
-    },
-  );
+  const eslintConfig: MigrateConfig = {
+    rules: rules as MigrateRules,
+  };
+
+  const oxlintResult = await migrate(eslintConfig, undefined, {
+    reporter,
+    withNursery: true,
+    typeAware: true,
+  });
 
   // Remove fields that are identical in every generated config and add no value
   // when the config is used via extends.

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -130,15 +130,23 @@ function resolvePluginConfig(pluginRef: string, visited = new Set<string>()): Es
 
 function createReporter() {
   const warnings: string[] = [];
-  const skipped: Record<string, string[]> = {};
+  const skipped: Record<RuleSkippedCategory, string[]> = {
+    nursery: [],
+    'type-aware': [],
+    'not-implemented': [],
+    unsupported: [],
+    'js-plugins': [],
+  };
   return {
-    addWarning: (message: string) => warnings.push(message),
-    getWarnings: () => warnings,
-    markSkipped: (rule: string, category: string) => {
-      (skipped[category] ??= []).push(rule);
+    addWarning: (message: string) => {
+      warnings.push(message);
     },
-    removeSkipped: (rule: string, category: string) => {
-      skipped[category] = (skipped[category] ?? []).filter((r) => r !== rule);
+    getWarnings: () => warnings,
+    markSkipped: (rule: string, category: RuleSkippedCategory) => {
+      skipped[category].push(rule);
+    },
+    removeSkipped: (rule: string, category: RuleSkippedCategory) => {
+      skipped[category] = skipped[category].filter((r) => r !== rule);
     },
     getSkippedRulesByCategory: () => skipped,
   };
@@ -381,6 +389,13 @@ const configs: ConfigEntry[] = [
   { sourcePackage: '@antfu/eslint-config', sourceConfig: '', resolveRules: fromAntfu },
 ];
 
+type RuleSkippedCategory =
+  | 'nursery'
+  | 'type-aware'
+  | 'not-implemented'
+  | 'unsupported'
+  | 'js-plugins';
+
 interface GenerateResult {
   config: ConfigEntry;
   oxlintResult: OxlintConfig;
@@ -403,11 +418,15 @@ for (const config of configs) {
 
   // Pass the flattened rules as a single ESLint flat config object.
   // migrate() returns an oxlint-compatible config with supported rules only.
-  const oxlintResult = await migrate({ rules }, undefined, {
-    reporter,
-    withNursery: true,
-    typeAware: true,
-  });
+  const oxlintResult = await migrate(
+    { rules } as unknown as Parameters<typeof migrate>[0],
+    undefined,
+    {
+      reporter,
+      withNursery: true,
+      typeAware: true,
+    },
+  );
 
   // Remove fields that are identical in every generated config and add no value
   // when the config is used via extends.

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -23,8 +23,21 @@ import migrate, { type default as Migrate } from '@oxlint/migrate';
 type OxlintConfig = Awaited<ReturnType<typeof Migrate>>;
 
 type MigrateInput = Parameters<typeof migrate>[0];
-type MigrateConfig = Awaited<MigrateInput> extends Array<infer C> ? C : Awaited<MigrateInput>;
-type MigrateRules = MigrateConfig extends { rules?: infer R } ? R : never;
+type ExtractConfig<T> =
+  T extends Promise<infer P> ? ExtractConfig<P> : T extends Array<infer C> ? ExtractConfig<C> : T;
+type ExtractRules<T> = T extends { rules?: infer R }
+  ? R
+  : T extends Promise<infer P>
+    ? ExtractRules<P>
+    : T extends Array<infer C>
+      ? ExtractRules<C>
+      : never;
+type MigrateConfig = ExtractConfig<MigrateInput>;
+type MigrateRules = NonNullable<ExtractRules<MigrateInput>>;
+type ResolvedRules = MigrateRules;
+type MigrateReporter = NonNullable<NonNullable<Parameters<typeof migrate>[2]>['reporter']>;
+type RuleSkippedCategory = Parameters<MigrateReporter['markSkipped']>[1];
+type SkippedRulesByCategory = ReturnType<MigrateReporter['getSkippedRulesByCategory']>;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, '..');
@@ -36,13 +49,10 @@ const generatedEndMarker = '<!-- GENERATED CONFIGS END -->';
 // Use createRequire so we can require() CJS ESLint configs from ESM context
 const req = createRequire(join(rootDir, 'package.json'));
 
-type EslintRuleValue = string | number | [string | number, ...unknown[]];
-type EslintRules = Record<string, EslintRuleValue>;
-
 interface OldStyleEslintConfig {
   extends?: string | string[];
   plugins?: string[];
-  rules?: EslintRules;
+  rules?: ResolvedRules;
   env?: Record<string, boolean>;
   settings?: Record<string, unknown>;
   parserOptions?: Record<string, unknown>;
@@ -53,12 +63,12 @@ interface OldStyleEslintConfig {
  * Recursively resolve an old-style ESLint config to a flat rules map.
  * Extends are resolved depth-first; later entries and the config's own rules win.
  */
-function flattenRules(configPath: string, visited = new Set<string>()): EslintRules {
+function flattenRules(configPath: string, visited = new Set<string>()): ResolvedRules {
   if (visited.has(configPath)) return {};
   visited.add(configPath);
 
   const config = req(configPath) as OldStyleEslintConfig;
-  const rules: EslintRules = {};
+  const rules: ResolvedRules = {};
 
   if (config.extends) {
     const exts = Array.isArray(config.extends) ? config.extends : [config.extends];
@@ -92,7 +102,7 @@ function flattenRules(configPath: string, visited = new Set<string>()): EslintRu
  * Resolve a `plugin:name/config` extends entry to a flat rules map.
  * Handles old-style plugin configs which may themselves have extends.
  */
-function resolvePluginConfig(pluginRef: string, visited = new Set<string>()): EslintRules {
+function resolvePluginConfig(pluginRef: string, visited = new Set<string>()): ResolvedRules {
   // pluginRef format: "plugin:<pluginName>/<configName>"
   const withoutPrefix = pluginRef.slice('plugin:'.length);
   const slashIdx = withoutPrefix.indexOf('/');
@@ -108,7 +118,7 @@ function resolvePluginConfig(pluginRef: string, visited = new Set<string>()): Es
     const pluginConfig = plugin.configs?.[configName];
     if (!pluginConfig) return {};
 
-    const rules: EslintRules = {};
+    const rules: ResolvedRules = {};
 
     if (pluginConfig.extends) {
       const exts = Array.isArray(pluginConfig.extends)
@@ -134,7 +144,7 @@ function resolvePluginConfig(pluginRef: string, visited = new Set<string>()): Es
 
 function createReporter() {
   const warnings: string[] = [];
-  const skipped: Record<RuleSkippedCategory, string[]> = {
+  const skipped: SkippedRulesByCategory = {
     nursery: [],
     'type-aware': [],
     'not-implemented': [],
@@ -162,7 +172,7 @@ interface ConfigEntry {
   /** config variant within the package, e.g. 'base'; empty string for the main export */
   sourceConfig: string;
   /** Returns the flat map of ESLint rules to migrate */
-  resolveRules: () => EslintRules;
+  resolveRules: () => ResolvedRules;
 }
 
 /**
@@ -195,19 +205,19 @@ const fromPackage = (pkg: string) => () => flattenRules(req.resolve(pkg));
 // @eslint/js uses flat config: configs.recommended / configs.all each have a
 // plain `rules` object we can pass directly to migrate.
 const eslintJs = req('@eslint/js') as {
-  configs: { recommended: { rules: EslintRules }; all: { rules: EslintRules } };
+  configs: { recommended: { rules: ResolvedRules }; all: { rules: ResolvedRules } };
 };
 
 // @typescript-eslint uses flat config arrays. Merge all rules from each array
 // entry to get the full effective rule set for a given config.
 const tsEslint = req('@typescript-eslint/eslint-plugin') as {
-  configs: Record<string, Array<{ rules?: EslintRules }> | { rules?: EslintRules }>;
+  configs: Record<string, Array<{ rules?: ResolvedRules }> | { rules?: ResolvedRules }>;
 };
 
 const fromTsEslint = (name: string) => () => {
   const cfg = tsEslint.configs[name];
   const entries = Array.isArray(cfg) ? cfg : [cfg];
-  const rules: EslintRules = {};
+  const rules: ResolvedRules = {};
   for (const entry of entries) Object.assign(rules, entry.rules ?? {});
   return rules;
 };
@@ -215,35 +225,35 @@ const fromTsEslint = (name: string) => () => {
 // eslint-config-xo uses flat config (ESM function returning an array of config objects).
 // We merge all rules from the returned entries to get the full effective rule set.
 const xoModule = await import('eslint-config-xo');
-const xoFn = xoModule.default as () => Array<{ rules?: EslintRules }>;
+const xoFn = xoModule.default as () => Array<{ rules?: ResolvedRules }>;
 const fromXo = () => {
   const entries = xoFn();
-  const rules: EslintRules = {};
+  const rules: ResolvedRules = {};
   for (const entry of entries) Object.assign(rules, entry.rules ?? {});
   return rules;
 };
 
 // eslint-config-problems exposes a plain flat config object with a `rules` property.
-const problemsConfig = req('eslint-config-problems') as { rules: EslintRules };
+const problemsConfig = req('eslint-config-problems') as { rules: ResolvedRules };
 
 // eslint-config-eslint (ESLint team's own config) uses flat config arrays loadable via require.
-type FlatConfigArray = Array<{ rules?: EslintRules }>;
+type FlatConfigArray = Array<{ rules?: ResolvedRules }>;
 const fromFlatArray = (pkg: string) => () => {
-  const entries = req(pkg) as FlatConfigArray | { rules?: EslintRules };
+  const entries = req(pkg) as FlatConfigArray | { rules?: ResolvedRules };
   const arr = Array.isArray(entries) ? entries : [entries];
-  const rules: EslintRules = {};
+  const rules: ResolvedRules = {};
   for (const entry of arr) Object.assign(rules, entry.rules ?? {});
   return rules;
 };
 
 // eslint-config-prettier disables all formatting rules that conflict with Prettier.
-const prettierConfig = req('eslint-config-prettier') as { rules: EslintRules };
+const prettierConfig = req('eslint-config-prettier') as { rules: ResolvedRules };
 
 // @antfu/eslint-config is an async ESM factory function returning a flat config array.
 const antfuModule = await import('@antfu/eslint-config');
 const antfuEntries = await (antfuModule.default as () => Promise<FlatConfigArray>)();
 const fromAntfu = () => {
-  const rules: EslintRules = {};
+  const rules: ResolvedRules = {};
   for (const entry of antfuEntries) Object.assign(rules, entry.rules ?? {});
   return rules;
 };
@@ -393,17 +403,10 @@ const configs: ConfigEntry[] = [
   { sourcePackage: '@antfu/eslint-config', sourceConfig: '', resolveRules: fromAntfu },
 ];
 
-type RuleSkippedCategory =
-  | 'nursery'
-  | 'type-aware'
-  | 'not-implemented'
-  | 'unsupported'
-  | 'js-plugins';
-
 interface GenerateResult {
   config: ConfigEntry;
   oxlintResult: OxlintConfig;
-  skipped: Record<string, string[]>;
+  skipped: SkippedRulesByCategory;
   strippedOptions: string[];
   warnings: string[];
 }
@@ -423,7 +426,7 @@ for (const config of configs) {
   // Pass the flattened rules as a single ESLint flat config object.
   // migrate() returns an oxlint-compatible config with supported rules only.
   const eslintConfig: MigrateConfig = {
-    rules: rules as MigrateRules,
+    rules,
   };
 
   const oxlintResult = await migrate(eslintConfig, undefined, {
@@ -506,7 +509,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   'js-plugins': 'Require JS plugin support',
 };
 
-function skippedSection(skipped: Record<string, string[]>): string {
+function skippedSection(skipped: SkippedRulesByCategory): string {
   const categories = Object.entries(skipped).filter(([, rules]) => rules.length > 0);
   if (categories.length === 0) return '';
 


### PR DESCRIPTION
### Motivation
- Running `oxlint` on the generate script produced type/lint errors due to an incompatible `Reporter` shape and an unsafe `migrate` call argument, which prevented lint-clean CI runs.
- The change aims to make the reporter and migrate invocation types explicit so `oxlint` and TypeScript accept the script.

### Description
- Introduced a `RuleSkippedCategory` union type and used it to strongly type skipped-rule bookkeeping so the reporter matches the expected `Reporter` contract.
- Initialized `skipped` as a `Record<RuleSkippedCategory, string[]>` and updated `markSkipped`/`removeSkipped` signatures to accept `RuleSkippedCategory` instead of `string`.
- Made `createReporter().addWarning` explicitly return `void` (changed push usage to a statement) to satisfy the reporter type.
- Adjusted the `migrate` invocation to pass the flattened rules via a safer cast (`{ rules } as unknown as Parameters<typeof migrate>[0]`) to align with the function signature.

### Testing
- Ran `pnpm fmt` (formatting completed successfully).
- Ran `pnpm exec oxlint .` and verified there were no `oxlint` errors after the changes.
- Ran `pnpm test` and observed all tests passed (`59` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8785f9b54832293add6a96753efd0)