### PR TITLE
ci: auto publish patched npm releases when package changes

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -54,11 +54,11 @@ jobs:
           tar -xzf "$local_tgz" -C "$local_dir/extracted"
 
           if diff -qr "$remote_dir/extracted/package" "$local_dir/extracted/package" >/tmp/package-diff.txt; then
-            echo "No differences with npm latest package."
+            echo "No differences with npm package at current version."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "should_bump=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Differences detected with npm latest package."
+            echo "Differences detected with npm package at current version."
             cat /tmp/package-diff.txt
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             echo "should_bump=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -34,13 +34,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check if publish package differs from npm latest
-        id: diff
+      - name: Decide publish/bump strategy
+        id: plan
         shell: bash
         run: |
           set -euo pipefail
 
           PACKAGE_NAME=$(node -p "require('./package.json').name")
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
 
           pnpm prepack
 
@@ -48,12 +49,24 @@ jobs:
           local_dir=$(mktemp -d)
 
           if (cd "$remote_dir" && npm pack "${PACKAGE_NAME}@latest" --silent >/dev/null 2>&1); then
+            REMOTE_VERSION=$(npm view "${PACKAGE_NAME}@latest" version)
+            echo "Local version: $LOCAL_VERSION"
+            echo "Remote version: $REMOTE_VERSION"
+
+            if [ "$LOCAL_VERSION" != "$REMOTE_VERSION" ]; then
+              echo "Version already differs; publish without bump."
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              echo "should_bump=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             remote_tgz=$(find "$remote_dir" -maxdepth 1 -name '*.tgz' -print -quit)
             mkdir -p "$remote_dir/extracted"
             tar -xzf "$remote_tgz" -C "$remote_dir/extracted"
           else
             echo "Package not found on npm yet; publishing required."
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "should_bump=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -64,35 +77,37 @@ jobs:
 
           if diff -qr "$remote_dir/extracted/package" "$local_dir/extracted/package" >/tmp/package-diff.txt; then
             echo "No differences with npm latest package."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "should_bump=false" >> "$GITHUB_OUTPUT"
           else
             echo "Differences detected with npm latest package."
             cat /tmp/package-diff.txt
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "should_bump=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump patch version
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.plan.outputs.should_bump == 'true'
         run: npm version patch --no-git-tag-version
 
       - name: Run checks before commit
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.plan.outputs.should_bump == 'true'
         run: pnpm before-commit
 
       - name: Commit version bump
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.plan.outputs.should_bump == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml
+          git add -A
           git commit -m "chore: release $(node -p \"require('./package.json').version\")"
 
       - name: Publish to npm
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.plan.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm publish --no-git-checks
 
       - name: Push version bump commit
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.plan.outputs.should_bump == 'true'
         run: git push

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -37,23 +37,12 @@ jobs:
           remote_dir=$(mktemp -d)
           local_dir=$(mktemp -d)
 
-          if (cd "$remote_dir" && npm pack "${PACKAGE_NAME}@latest" --silent >/dev/null 2>&1); then
-            REMOTE_VERSION=$(npm view "${PACKAGE_NAME}@latest" version)
-            echo "Local version: $LOCAL_VERSION"
-            echo "Remote version: $REMOTE_VERSION"
-
-            if [ "$LOCAL_VERSION" != "$REMOTE_VERSION" ]; then
-              echo "Version already differs; publish without bump."
-              echo "should_publish=true" >> "$GITHUB_OUTPUT"
-              echo "should_bump=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
+          if (cd "$remote_dir" && npm pack "${PACKAGE_NAME}@${LOCAL_VERSION}" --silent >/dev/null 2>&1); then
             remote_tgz=$(find "$remote_dir" -maxdepth 1 -name '*.tgz' -print -quit)
             mkdir -p "$remote_dir/extracted"
             tar -xzf "$remote_tgz" -C "$remote_dir/extracted"
           else
-            echo "Package not found on npm yet; publishing required."
+            echo "Current version not found on npm; publishing required without bump."
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             echo "should_bump=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -89,13 +78,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore: release $(node -p \"require('./package.json').version\")"
+          git commit -m "Release $(node -p \"require('./package.json').version\")"
 
       - name: Publish to npm
         if: steps.plan.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --no-git-checks
+        run: pnpm publish
 
       - name: Push version bump commit
         if: steps.plan.outputs.should_bump == 'true'

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -14,25 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.29.3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: lts/*
           cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
 
       - name: Decide publish/bump strategy
         id: plan

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,98 @@
+name: Auto publish
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish-if-changed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check if publish package differs from npm latest
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+          pnpm prepack
+
+          remote_dir=$(mktemp -d)
+          local_dir=$(mktemp -d)
+
+          if (cd "$remote_dir" && npm pack "${PACKAGE_NAME}@latest" --silent >/dev/null 2>&1); then
+            remote_tgz=$(find "$remote_dir" -maxdepth 1 -name '*.tgz' -print -quit)
+            mkdir -p "$remote_dir/extracted"
+            tar -xzf "$remote_tgz" -C "$remote_dir/extracted"
+          else
+            echo "Package not found on npm yet; publishing required."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          (cd "$local_dir" && npm pack "$GITHUB_WORKSPACE/configs" --silent >/dev/null)
+          local_tgz=$(find "$local_dir" -maxdepth 1 -name '*.tgz' -print -quit)
+          mkdir -p "$local_dir/extracted"
+          tar -xzf "$local_tgz" -C "$local_dir/extracted"
+
+          if diff -qr "$remote_dir/extracted/package" "$local_dir/extracted/package" >/tmp/package-diff.txt; then
+            echo "No differences with npm latest package."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Differences detected with npm latest package."
+            cat /tmp/package-diff.txt
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump patch version
+        if: steps.diff.outputs.changed == 'true'
+        run: npm version patch --no-git-tag-version
+
+      - name: Run checks before commit
+        if: steps.diff.outputs.changed == 'true'
+        run: pnpm before-commit
+
+      - name: Commit version bump
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json pnpm-lock.yaml
+          git commit -m "chore: release $(node -p \"require('./package.json').version\")"
+
+      - name: Publish to npm
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --no-git-checks
+
+      - name: Push version bump commit
+        if: steps.diff.outputs.changed == 'true'
+        run: git push


### PR DESCRIPTION
### Motivation
- Automate publishing when the distributable `configs/` differs from the currently published npm package so releases aren't forgotten. 
- Ensure a deterministic, minimal (patch) version bump, run repository checks, publish to npm, and push the version bump back to git.

### Description
- Add a new workflow file at `.github/workflows/auto-publish.yml` that runs on `push` to `main` and `workflow_dispatch` and is granted `contents: write` to commit/push a version bump. 
- The job packs the currently published npm package (`npm pack <pkg>@latest`) and the local `configs/` output (`npm pack $GITHUB_WORKSPACE/configs`), extracts both, and uses `diff -qr` to detect changes. 
- When changes are detected (or the package is not yet on npm) the workflow runs `npm version patch --no-git-tag-version`, executes `pnpm before-commit`, commits `package.json` and `pnpm-lock.yaml`, publishes via `pnpm publish` using `NODE_AUTH_TOKEN`, and pushes the commit. 
- The workflow is careful to skip bump/publish/push if there is no detected diff and uses `pnpm prepack` to generate the publishable contents prior to comparison. 

### Testing
- Ran `pnpm before-commit`, which performs `pnpm generate`, `pnpm test`, and `pnpm oxlint`, and it completed successfully. 
- The test suite reported `# tests 130` with `# pass 130` and no failures. 
- `oxlint` completed with `Found 0 warnings and 0 errors`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90284cd9c83228d77f78903b85b37)