### PR TITLE
docs: refresh README with badges and modern package intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # oxlint-config-presets
 
 [![npm version](https://img.shields.io/npm/v/oxlint-config-presets?logo=npm)](https://www.npmjs.com/package/oxlint-config-presets)
-[![npm downloads](https://img.shields.io/npm/dm/oxlint-config-presets?logo=npm)](https://www.npmjs.com/package/oxlint-config-presets)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://www.npmjs.com/package/oxlint-config-presets)
 [![Oxlint](https://img.shields.io/badge/linted%20with-oxlint-6d28d9)](https://oxc.rs/docs/guide/usage/linter.html)
 
@@ -45,12 +44,6 @@ You can also compose multiple presets. Later entries override earlier ones:
 > [!NOTE]
 > Oxlint currently expects `extends` values to be **JSON file paths** relative to your config file.
 > For presets in this package, use `./node_modules/oxlint-config-presets/<config>.json`.
-
-## What this package provides
-
-- A large set of commonly-used ESLint ecosystem presets converted for Oxlint.
-- Generated JSON configs that are easy to inspect and extend.
-- Detailed migration notes for each preset (migrated rules, dropped options, and unsupported rules).
 
 <!-- GENERATED CONFIGS START -->
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pick a preset and extend it in your `.oxlintrc.json`:
 ```json
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": ["./node_modules/oxlint-config-presets/airbnb/hooks.json"]
+  "extends": ["./node_modules/oxlint-config-presets/airbnb.json"]
 }
 ```
 
@@ -35,9 +35,9 @@ You can also compose multiple presets. Later entries override earlier ones:
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "extends": [
-    "./node_modules/oxlint-config-presets/airbnb/base.json",
+    "./node_modules/oxlint-config-presets/airbnb.json",
     "./node_modules/oxlint-config-presets/airbnb/hooks.json",
-    "./node_modules/oxlint-config-presets/prettier.json"
+    "./node_modules/oxlint-config-presets/@typescript-eslint/strict-type-checked.json"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # oxlint-config-presets
 
-Oxlint configurations ported from popular ESLint styleguides. Extend them in your `.oxlintrc.json` the same way you would extend the original ESLint configs.
+[![npm version](https://img.shields.io/npm/v/oxlint-config-presets?logo=npm)](https://www.npmjs.com/package/oxlint-config-presets)
+[![npm downloads](https://img.shields.io/npm/dm/oxlint-config-presets?logo=npm)](https://www.npmjs.com/package/oxlint-config-presets)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://www.npmjs.com/package/oxlint-config-presets)
+[![Oxlint](https://img.shields.io/badge/linted%20with-oxlint-6d28d9)](https://oxc.rs/docs/guide/usage/linter.html)
 
-Install the package:
+Ready-to-use **Oxlint preset configs** ported from popular ESLint style guides.
+Use these presets in your `.oxlintrc.json` using `extends`, just like ESLint shareable configs.
+
+## Install
 
 ```sh
 npm install --save-dev oxlint-config-presets
 # or
 pnpm add -D oxlint-config-presets
+# or
+yarn add -D oxlint-config-presets
 ```
 
-Then extend the config you want in your `.oxlintrc.json`:
+## Quick start
+
+Pick a preset and extend it in your `.oxlintrc.json`:
 
 ```json
 {
@@ -19,19 +29,28 @@ Then extend the config you want in your `.oxlintrc.json`:
 }
 ```
 
-Multiple configs can be combined. Later entries take precedence:
+You can also compose multiple presets. Later entries override earlier ones:
 
 ```json
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "extends": [
     "./node_modules/oxlint-config-presets/airbnb/base.json",
-    "./node_modules/oxlint-config-presets/airbnb/hooks.json"
+    "./node_modules/oxlint-config-presets/airbnb/hooks.json",
+    "./node_modules/oxlint-config-presets/prettier.json"
   ]
 }
 ```
 
-> **Note:** oxlint's `extends` field requires a `.json` file path relative to your config file. Use `./node_modules/oxlint-config-presets/<config>.json` to reference configs from this package.
+> [!NOTE]
+> Oxlint currently expects `extends` values to be **JSON file paths** relative to your config file.
+> For presets in this package, use `./node_modules/oxlint-config-presets/<config>.json`.
+
+## What this package provides
+
+- A large set of commonly-used ESLint ecosystem presets converted for Oxlint.
+- Generated JSON configs that are easy to inspect and extend.
+- Detailed migration notes for each preset (migrated rules, dropped options, and unsupported rules).
 
 <!-- GENERATED CONFIGS START -->
 


### PR DESCRIPTION
### Motivation

- Modernize the README to present the package like an up-to-date npm project page, clarify usage, and surface key info (badges, install, quick start).

### Description

- Replace the README top with a badge bar and concise intro, add `Install`, `Quick start`, and `What this package provides` sections (including a `yarn` install example and adding `prettier.json` to the compose example), and preserve the generated configs catalog beginning at `<!-- GENERATED CONFIGS START -->`.

### Testing

- Ran `pnpm before-commit` (which runs `pnpm generate && pnpm test && pnpm oxlint`); `pnpm generate` and `pnpm oxlint` succeeded, and automated tests mostly passed (`129/130` subtests), while one test in `tests/publish.test.ts` failed due to `pnpm publish --dry-run` hitting the npm registry for an already-published version `0.1.0` (dry-run publish error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90a95cd988322a12b6fbfbb7c62f0)