### PR TITLE
test: switch publish dry-run check to pnpm pack --json

### DIFF
--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -7,19 +7,35 @@ import { fileURLToPath } from 'node:url';
 
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-const result = spawnSync('pnpm', ['publish', '--dry-run', '--no-git-checks'], {
+const result = spawnSync('pnpm', ['pack', '--dry-run', '--json'], {
   cwd: rootDir,
   encoding: 'utf-8',
 });
 
-// Combine stdout + stderr; pnpm routes npm notice lines through stderr
 const output = result.stdout + result.stderr;
 
-// Lines look like: "npm notice 1.23kB airbnb/index.json"
-const publishedFiles = [...output.matchAll(/npm notice\s+\S+\s+(.+)/g)].map((m) => m[1].trim());
+interface PackOutput {
+  files: Array<{ path: string }>;
+}
+
+function parsePackOutput(raw: string): PackOutput {
+  const jsonStart = raw.lastIndexOf('\n{');
+  const json = (jsonStart >= 0 ? raw.slice(jsonStart + 1) : raw).trim();
+
+  try {
+    return JSON.parse(json) as PackOutput;
+  } catch (error) {
+    throw new Error(
+      `Unable to parse pnpm pack --json output:\n${raw}\n\nParse error: ${String(error)}`,
+    );
+  }
+}
+
+const packOutput = parsePackOutput(output);
+const publishedFiles = packOutput.files.map((file) => file.path);
 
 test('dry-run succeeds', () => {
-  assert.equal(result.status, 0, `pnpm publish exited ${result.status}:\n${output}`);
+  assert.equal(result.status, 0, `pnpm pack --dry-run exited ${result.status}:\n${output}`);
 });
 
 test('package.json is included', () => {


### PR DESCRIPTION
### Motivation
- The `pnpm publish --dry-run` test is flaky in CI because it depends on npm authentication and on the package version not already existing in the registry. 
- The goal is to validate tarball contents deterministically without requiring registry access or credentials.

### Description
- Replace the `pnpm publish --dry-run --no-git-checks` invocation with `pnpm pack --dry-run --json` in `tests/publish.test.ts` so the test inspects the local tarball contents. 
- Add `parsePackOutput` logic to extract the JSON payload from `pnpm pack --json` output even when prepack lifecycle logs appear before the JSON. 
- Derive `publishedFiles` from `packOutput.files[].path` and update the dry-run exit assertion text while keeping all existing inclusion/exclusion assertions (configs, `README.md`, `scripts/` exclusion, `pnpm-lock.yaml` exclusion) unchanged.

### Testing
- Ran `pnpm test` which executed the updated `tests/publish.test.ts` and all tests passed (130 passed, 0 failed). 
- Ran `pnpm before-commit` which runs `pnpm generate`, `pnpm test`, and `pnpm oxlint`, and the full workflow completed successfully with no lint errors. 
- Also exercised `pnpm pack --dry-run --json` manually to verify the produced JSON payload and that the test parsing handles prepack logs correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90b69ccd88322b780bcf16a7a9015)