### PR TITLE
generator: record source package versions and include migrate version in generated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,15 @@ Multiple configs can be combined. Later entries take precedence:
 | `eslint-plugin-vue`                | `vue2-strongly-recommended`     | `vue/vue2-strongly-recommended.json`               |
 | `eslint-plugin-vue`                | `vue2-recommended`              | `vue/vue2-recommended.json`                        |
 
+Generated with `@oxlint/migrate@1.57.0`.
+
 ### `airbnb.json`
 
 ```json
 "./node_modules/oxlint-config-presets/airbnb.json"
 ```
+
+Extracted from `eslint-config-airbnb@19.0.4`.
 
 <details>
 <summary>210 rules successfully migrated</summary>
@@ -151,6 +155,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/airbnb/base.json"
 ```
 
+Extracted from `eslint-config-airbnb@19.0.4`.
+
 <details>
 <summary>150 rules successfully migrated</summary>
 
@@ -191,6 +197,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/airbnb/hooks.json"
 ```
 
+Extracted from `eslint-config-airbnb@19.0.4`.
+
 <details>
 <summary>2 rules successfully migrated</summary>
 
@@ -203,6 +211,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/airbnb/legacy.json"
 ```
+
+Extracted from `eslint-config-airbnb@19.0.4`.
 
 <details>
 <summary>116 rules successfully migrated</summary>
@@ -229,6 +239,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/airbnb/whitespace.json"
 ```
+
+Extracted from `eslint-config-airbnb@19.0.4`.
 
 <details>
 <summary>210 rules successfully migrated</summary>
@@ -273,6 +285,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/standard.json"
 ```
 
+Extracted from `eslint-config-standard@17.1.0`.
+
 <details>
 <summary>99 rules successfully migrated</summary>
 
@@ -298,6 +312,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/google.json"
 ```
+
+Extracted from `eslint-config-google@0.14.0`.
 
 <details>
 <summary>21 rules successfully migrated</summary>
@@ -325,6 +341,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@typescript-eslint/recommended.json"
 ```
 
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
+
 <details>
 <summary>20 rules successfully migrated</summary>
 
@@ -337,6 +355,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/@typescript-eslint/recommended-type-checked.json"
 ```
+
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
 
 <details>
 <summary>43 rules successfully migrated</summary>
@@ -351,6 +371,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@typescript-eslint/strict.json"
 ```
 
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
+
 <details>
 <summary>28 rules successfully migrated</summary>
 
@@ -363,6 +385,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/@typescript-eslint/strict-type-checked.json"
 ```
+
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
 
 <details>
 <summary>68 rules successfully migrated</summary>
@@ -377,6 +401,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@typescript-eslint/stylistic.json"
 ```
 
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
+
 <details>
 <summary>13 rules successfully migrated</summary>
 
@@ -390,6 +416,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@typescript-eslint/stylistic-type-checked.json"
 ```
 
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
+
 <details>
 <summary>21 rules successfully migrated</summary>
 
@@ -402,6 +430,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/@typescript-eslint/all.json"
 ```
+
+Extracted from `@typescript-eslint/eslint-plugin@8.57.2`.
 
 <details>
 <summary>120 rules successfully migrated</summary>
@@ -429,6 +459,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@eslint/recommended.json"
 ```
 
+Extracted from `@eslint/js@10.0.1`.
+
 <details>
 <summary>61 rules successfully migrated</summary>
 
@@ -455,6 +487,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@eslint/all.json"
 ```
 
+Extracted from `@eslint/js@10.0.1`.
+
 <details>
 <summary>171 rules successfully migrated</summary>
 
@@ -480,6 +514,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/xo.json"
 ```
+
+Extracted from `eslint-config-xo@0.51.0`.
 
 <details>
 <summary>182 rules have no oxlint equivalent</summary>
@@ -511,6 +547,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/problems.json"
 ```
 
+Extracted from `eslint-config-problems@9.0.0`.
+
 <details>
 <summary>105 rules successfully migrated</summary>
 
@@ -536,6 +574,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/hardcore.json"
 ```
+
+Extracted from `eslint-config-hardcore@49.0.0`.
 
 <details>
 <summary>284 rules successfully migrated</summary>
@@ -582,6 +622,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/wikimedia.json"
 ```
 
+Extracted from `eslint-config-wikimedia@0.32.3`.
+
 <details>
 <summary>110 rules successfully migrated</summary>
 
@@ -624,6 +666,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/eslint.json"
 ```
 
+Extracted from `eslint-config-eslint@14.0.0`.
+
 <details>
 <summary>156 rules successfully migrated</summary>
 
@@ -654,6 +698,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/eslint/base.json"
 ```
 
+Extracted from `eslint-config-eslint@14.0.0`.
+
 <details>
 <summary>156 rules successfully migrated</summary>
 
@@ -683,6 +729,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/alloy.json"
 ```
+
+Extracted from `eslint-config-alloy@5.1.2`.
 
 <details>
 <summary>98 rules successfully migrated</summary>
@@ -721,6 +769,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/alloy/react.json"
 ```
 
+Extracted from `eslint-config-alloy@5.1.2`.
+
 <details>
 <summary>29 rules successfully migrated</summary>
 
@@ -746,6 +796,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/alloy/typescript.json"
 ```
+
+Extracted from `eslint-config-alloy@5.1.2`.
 
 <details>
 <summary>25 rules successfully migrated</summary>
@@ -773,11 +825,15 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/prettier.json"
 ```
 
+Extracted from `eslint-config-prettier@10.1.8`.
+
 ### `@antfu.json`
 
 ```json
 "./node_modules/oxlint-config-presets/@antfu.json"
 ```
+
+Extracted from `@antfu/eslint-config@7.7.3`.
 
 <details>
 <summary>109 rules successfully migrated</summary>
@@ -822,6 +878,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/import/recommended.json"
 ```
 
+Extracted from `eslint-plugin-import@2.32.0`.
+
 <details>
 <summary>7 rules successfully migrated</summary>
 
@@ -843,6 +901,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/import/errors.json"
 ```
+
+Extracted from `eslint-plugin-import@2.32.0`.
 
 <details>
 <summary>4 rules successfully migrated</summary>
@@ -866,6 +926,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/import/warnings.json"
 ```
 
+Extracted from `eslint-plugin-import@2.32.0`.
+
 <details>
 <summary>3 rules successfully migrated</summary>
 
@@ -879,17 +941,23 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/import/react.json"
 ```
 
+Extracted from `eslint-plugin-import@2.32.0`.
+
 ### `import/typescript.json`
 
 ```json
 "./node_modules/oxlint-config-presets/import/typescript.json"
 ```
 
+Extracted from `eslint-plugin-import@2.32.0`.
+
 ### `import-x/recommended.json`
 
 ```json
 "./node_modules/oxlint-config-presets/import-x/recommended.json"
 ```
+
+Extracted from `eslint-plugin-import-x@4.16.2`.
 
 <details>
 <summary>7 rules successfully migrated</summary>
@@ -913,6 +981,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/import-x/errors.json"
 ```
 
+Extracted from `eslint-plugin-import-x@4.16.2`.
+
 <details>
 <summary>4 rules successfully migrated</summary>
 
@@ -934,6 +1004,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/import-x/warnings.json"
 ```
+
+Extracted from `eslint-plugin-import-x@4.16.2`.
 
 <details>
 <summary>3 rules successfully migrated</summary>
@@ -957,17 +1029,23 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/import-x/react.json"
 ```
 
+Extracted from `eslint-plugin-import-x@4.16.2`.
+
 ### `import-x/typescript.json`
 
 ```json
 "./node_modules/oxlint-config-presets/import-x/typescript.json"
 ```
 
+Extracted from `eslint-plugin-import-x@4.16.2`.
+
 ### `next/recommended.json`
 
 ```json
 "./node_modules/oxlint-config-presets/next/recommended.json"
 ```
+
+Extracted from `eslint-config-next@15.5.14`.
 
 <details>
 <summary>21 rules successfully migrated</summary>
@@ -982,6 +1060,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/next/core-web-vitals.json"
 ```
 
+Extracted from `eslint-config-next@15.5.14`.
+
 <details>
 <summary>21 rules successfully migrated</summary>
 
@@ -994,6 +1074,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/react-perf/recommended.json"
 ```
+
+Extracted from `eslint-plugin-react-perf@3.3.3`.
 
 <details>
 <summary>3 rules successfully migrated</summary>
@@ -1008,6 +1090,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/react-perf/all.json"
 ```
 
+Extracted from `eslint-plugin-react-perf@3.3.3`.
+
 <details>
 <summary>4 rules successfully migrated</summary>
 
@@ -1020,6 +1104,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/jsdoc/recommended.json"
 ```
+
+Extracted from `eslint-plugin-jsdoc@62.8.1`.
 
 <details>
 <summary>18 rules successfully migrated</summary>
@@ -1043,6 +1129,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/jsdoc/recommended-typescript.json"
 ```
 
+Extracted from `eslint-plugin-jsdoc@62.8.1`.
+
 <details>
 <summary>15 rules successfully migrated</summary>
 
@@ -1064,6 +1152,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/jsdoc/recommended-typescript-flavor.json"
 ```
+
+Extracted from `eslint-plugin-jsdoc@62.8.1`.
 
 <details>
 <summary>18 rules successfully migrated</summary>
@@ -1087,6 +1177,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/jsdoc/recommended-tsdoc.json"
 ```
 
+Extracted from `eslint-plugin-jsdoc@62.8.1`.
+
 <details>
 <summary>15 rules successfully migrated</summary>
 
@@ -1108,6 +1200,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/jsx-a11y/recommended.json"
 ```
+
+Extracted from `eslint-plugin-jsx-a11y@6.10.2`.
 
 <details>
 <summary>27 rules successfully migrated</summary>
@@ -1131,6 +1225,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/jsx-a11y/strict.json"
 ```
 
+Extracted from `eslint-plugin-jsx-a11y@6.10.2`.
+
 <details>
 <summary>27 rules successfully migrated</summary>
 
@@ -1152,6 +1248,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/n/recommended.json"
 ```
+
+Extracted from `eslint-plugin-n@17.24.0`.
 
 <details>
 <summary>1 rules successfully migrated</summary>
@@ -1175,6 +1273,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/n/recommended-module.json"
 ```
 
+Extracted from `eslint-plugin-n@17.24.0`.
+
 <details>
 <summary>1 rules successfully migrated</summary>
 
@@ -1196,6 +1296,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/n/recommended-script.json"
 ```
+
+Extracted from `eslint-plugin-n@17.24.0`.
 
 <details>
 <summary>1 rules successfully migrated</summary>
@@ -1219,6 +1321,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/promise/recommended.json"
 ```
 
+Extracted from `eslint-plugin-promise@7.2.1`.
+
 <details>
 <summary>10 rules successfully migrated</summary>
 
@@ -1231,6 +1335,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/jest/recommended.json"
 ```
+
+Extracted from `eslint-plugin-jest@28.14.0`.
 
 <details>
 <summary>18 rules successfully migrated</summary>
@@ -1254,6 +1360,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/jest/style.json"
 ```
 
+Extracted from `eslint-plugin-jest@28.14.0`.
+
 <details>
 <summary>4 rules successfully migrated</summary>
 
@@ -1266,6 +1374,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/jest/all.json"
 ```
+
+Extracted from `eslint-plugin-jest@28.14.0`.
 
 <details>
 <summary>50 rules successfully migrated</summary>
@@ -1293,6 +1403,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/@vitest/recommended.json"
 ```
 
+Extracted from `@vitest/eslint-plugin@1.6.13`.
+
 <details>
 <summary>14 rules successfully migrated</summary>
 
@@ -1314,6 +1426,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/@vitest/all.json"
 ```
+
+Extracted from `@vitest/eslint-plugin@1.6.13`.
 
 <details>
 <summary>54 rules successfully migrated</summary>
@@ -1341,6 +1455,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/vue/essential.json"
 ```
 
+Extracted from `eslint-plugin-vue@10.8.0`.
+
 <details>
 <summary>7 rules successfully migrated</summary>
 
@@ -1367,6 +1483,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/vue/strongly-recommended.json"
 ```
 
+Extracted from `eslint-plugin-vue@10.8.0`.
+
 <details>
 <summary>25 rules have no oxlint equivalent</summary>
 
@@ -1385,6 +1503,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/vue/recommended.json"
 ```
+
+Extracted from `eslint-plugin-vue@10.8.0`.
 
 <details>
 <summary>2 rules successfully migrated</summary>
@@ -1412,6 +1532,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/vue/vue2-essential.json"
 ```
 
+Extracted from `eslint-plugin-vue@10.8.0`.
+
 <details>
 <summary>4 rules successfully migrated</summary>
 
@@ -1438,6 +1560,8 @@ These rules are enabled but their configuration options were dropped because oxl
 "./node_modules/oxlint-config-presets/vue/vue2-strongly-recommended.json"
 ```
 
+Extracted from `eslint-plugin-vue@10.8.0`.
+
 <details>
 <summary>23 rules have no oxlint equivalent</summary>
 
@@ -1456,6 +1580,8 @@ These rules are enabled but their configuration options were dropped because oxl
 ```json
 "./node_modules/oxlint-config-presets/vue/vue2-recommended.json"
 ```
+
+Extracted from `eslint-plugin-vue@10.8.0`.
 
 <details>
 <summary>2 rules successfully migrated</summary>

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -14,7 +14,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -201,10 +201,16 @@ function createReporter() {
 interface ConfigEntry {
   /** npm package name of the source ESLint config, e.g. 'eslint-config-airbnb' */
   sourcePackage: string;
+  /** Optional package name used only for version reporting in README. */
+  sourceVersionPackage?: string;
   /** config variant within the package, e.g. 'base'; empty string for the main export */
   sourceConfig: string;
   /** Returns an ESLint flat config (or array) to migrate */
   resolveConfig: () => MigrateConfig | MigrateConfig[];
+}
+
+interface ConfigEntryWithVersion extends ConfigEntry {
+  sourcePackageVersion: string;
 }
 
 /**
@@ -230,6 +236,70 @@ const outputFor = (cfg: ConfigEntry) => {
 
 /** Full import path as used in an oxlintrc extends array */
 const oxlintConfigFor = (cfg: ConfigEntry) => `oxlint-config-presets/${outputFor(cfg)}`;
+
+const packageVersionCache = new Map<string, string>();
+const lockfilePath = join(rootDir, 'pnpm-lock.yaml');
+const lockfileContent = existsSync(lockfilePath) ? readFileSync(lockfilePath, 'utf-8') : '';
+
+function escapeForRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getVersionFromPnpmLock(pkg: string): string | null {
+  if (!lockfileContent) return null;
+  const escapedPkg = escapeForRegex(pkg);
+  const directEntryPattern = new RegExp(`^\\s{2}'?${escapedPkg}@([^:(\\s']+)'?:$`, 'm');
+  const directMatch = lockfileContent.match(directEntryPattern);
+  if (directMatch) return directMatch[1];
+
+  const peerEntryPattern = new RegExp(`^\\s{2}'?${escapedPkg}@([^:(\\s']+)\\(`, 'm');
+  const peerMatch = lockfileContent.match(peerEntryPattern);
+  if (peerMatch) return peerMatch[1];
+  return null;
+}
+
+function getInstalledPackageVersion(pkg: string): string {
+  const cached = packageVersionCache.get(pkg);
+  if (cached) return cached;
+
+  const readVersion = (packageJsonPath: string): string | null => {
+    try {
+      const pkgJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown };
+      return typeof pkgJson.version === 'string' ? pkgJson.version : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const version = (() => {
+    try {
+      const pkgJsonPath = req.resolve(`${pkg}/package.json`);
+      return readVersion(pkgJsonPath) ?? 'unknown';
+    } catch {
+      try {
+        const entryPath = req.resolve(pkg);
+        let currentDir = dirname(entryPath);
+        const rootDirPath = resolve(currentDir, '/');
+
+        while (currentDir !== rootDirPath) {
+          const packageJsonPath = join(currentDir, 'package.json');
+          if (existsSync(packageJsonPath)) {
+            return readVersion(packageJsonPath) ?? 'unknown';
+          }
+          currentDir = dirname(currentDir);
+        }
+      } catch {
+        // Ignore and fall back to unknown.
+      }
+      const versionFromLockfile = getVersionFromPnpmLock(pkg);
+      if (versionFromLockfile) return versionFromLockfile;
+      return 'unknown';
+    }
+  })();
+
+  packageVersionCache.set(pkg, version);
+  return version;
+}
 
 // Shorthand for old-style shareable configs resolved via flattenRules.
 const fromPackage = (pkg: string) => () => {
@@ -509,11 +579,13 @@ const configs: ConfigEntry[] = [
   // ── next / react-perf ─────────────────────────────────────────────────────
   {
     sourcePackage: 'eslint-config-next',
+    sourceVersionPackage: '@next/eslint-plugin-next',
     sourceConfig: 'recommended',
     resolveConfig: fromPluginPackage('@next/eslint-plugin-next', 'recommended'),
   },
   {
     sourcePackage: 'eslint-config-next',
+    sourceVersionPackage: '@next/eslint-plugin-next',
     sourceConfig: 'core-web-vitals',
     resolveConfig: fromPluginPackage('@next/eslint-plugin-next', 'core-web-vitals'),
   },
@@ -641,7 +713,7 @@ const configs: ConfigEntry[] = [
 ];
 
 interface GenerateResult {
-  config: ConfigEntry;
+  config: ConfigEntryWithVersion;
   oxlintResult: OxlintConfig;
   skipped: SkippedRulesByCategory;
   strippedOptions: string[];
@@ -743,7 +815,12 @@ for (const config of configs) {
   console.log(`  Written to configs/${outputFor(config)} (${ruleCount} oxlint rules)`);
 
   results.push({
-    config,
+    config: {
+      ...config,
+      sourcePackageVersion: getInstalledPackageVersion(
+        config.sourceVersionPackage ?? config.sourcePackage,
+      ),
+    },
     oxlintResult,
     skipped: reporter.getSkippedRulesByCategory(),
     strippedOptions,
@@ -784,6 +861,7 @@ function skippedSection(skipped: SkippedRulesByCategory): string {
 }
 
 const rootReadme = readFileSync(readmePath, 'utf-8').trimEnd();
+const oxlintMigrateVersion = getInstalledPackageVersion('@oxlint/migrate');
 
 const tableRows = results
   .map(
@@ -796,7 +874,9 @@ const table =
   `## Available configs\n\n` +
   `| Source package | Source config | Oxlint config |\n` +
   `|---|---|---|\n` +
-  tableRows;
+  tableRows +
+  `\n\n` +
+  `Generated with \`@oxlint/migrate@${oxlintMigrateVersion}\`.`;
 
 function migratedSection(rules: OxlintConfig['rules'], strippedOptions: string[]): string {
   const names = Object.keys(rules ?? {}).filter((name) => !strippedOptions.includes(name));
@@ -848,7 +928,8 @@ const configSections = results
   .map(({ config, oxlintResult, skipped, strippedOptions, warnings }) => {
     const extendsExample =
       `\`\`\`json\n` + `"./node_modules/oxlint-config-presets/${outputFor(config)}"\n` + `\`\`\``;
-    const parts: string[] = [`### \`${outputFor(config)}\``, extendsExample];
+    const sourceVersionInfo = `Extracted from \`${config.sourcePackage}@${config.sourcePackageVersion}\`.`;
+    const parts: string[] = [`### \`${outputFor(config)}\``, extendsExample, sourceVersionInfo];
 
     const migrated = migratedSection(oxlintResult.rules, strippedOptions);
     if (migrated) parts.push(migrated);


### PR DESCRIPTION
### Motivation

- Improve traceability of generated oxlint presets by recording the source ESLint package versions used during generation and the `@oxlint/migrate` version that produced the output.

### Description

- Enhance `scripts/generate.ts` to detect installed package versions with `getInstalledPackageVersion`, caching results in `packageVersionCache` and falling back to `pnpm-lock.yaml` via `getVersionFromPnpmLock` when necessary.
- Add `sourceVersionPackage` to `ConfigEntry` and include `sourcePackageVersion` in the `results` objects so the README per-config sections include an `Extracted from \\`pkg@version\\`` line.
- Append the `@oxlint/migrate` version to the generated configs table as `Generated with \\`@oxlint/migrate@...\\`` and introduce `oxlintMigrateVersion` populated from installed packages.
- Small I/O and import changes: import `existsSync`, read `pnpm-lock.yaml`, add `escapeForRegex`, and set `sourceVersionPackage` for `eslint-config-next` entries to prefer `@next/eslint-plugin-next` for version reporting.

### Testing

- Ran the generator with `pnpm generate` which completed and produced updated `README.md` and generated config files under `configs/`, with per-config "Extracted from `pkg@version`" lines and a "Generated with `@oxlint/migrate@...`" footer, indicating success.
- The script handled packages that could not be resolved via `require` by falling back to `pnpm-lock.yaml` and returned versions (or `unknown`) without crashing.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90ac51d488322b63264747c35a54e)