### PR TITLE
prepack: exclude only non-publish package.json fields to preserve metadata

### DIFF
--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -2,9 +2,9 @@
  * Writes a clean package.json into configs/ before publishing.
  *
  * pnpm requires a package.json to be present in publishConfig.directory.
- * This script derives it from the root package.json, keeping only the fields
- * relevant to consumers and dropping dev-only ones (devDependencies, scripts,
- * publishConfig, etc.).
+ * This script derives it from the root package.json, dropping only fields
+ * that are not needed by consumers (devDependencies, scripts,
+ * publishConfig, and packageManager).
  *
  * Invoked automatically by pnpm via the "prepack" lifecycle hook.
  */
@@ -17,21 +17,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 
 interface PackageJson {
-  name: string;
-  version: string;
-  description?: string;
-  license?: string;
   [key: string]: unknown;
 }
 
 const root = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8')) as PackageJson;
 
-const publishPkg: Partial<PackageJson> = {
-  name: root.name,
-  version: root.version,
-  description: root.description,
-  license: root.license,
-};
+const excludedKeys = new Set(['publishConfig', 'scripts', 'packageManager', 'devDependencies']);
+const publishPkg = Object.fromEntries(
+  Object.entries(root).filter(([key]) => !excludedKeys.has(key)),
+);
 
 writeFileSync(join(rootDir, 'configs', 'package.json'), JSON.stringify(publishPkg, null, 2) + '\n');
 copyFileSync(join(rootDir, 'README.md'), join(rootDir, 'configs', 'README.md'));


### PR DESCRIPTION
### Motivation
- Ensure published `configs/package.json` preserves consumer-facing metadata (e.g. `homepage`, `repository`, `keywords`) by removing only fields that are not needed for consumers instead of whitelisting a small fixed set.

### Description
- Reworked `scripts/prepack.ts` to build the publish package by filtering out an exclusion set instead of manually selecting fields.
- The excluded keys are now `publishConfig`, `scripts`, `packageManager`, and `devDependencies` in `scripts/prepack.ts`.
- The script still writes `configs/package.json` and copies `README.md` into `configs/` as before.

### Testing
- Ran `pnpm prepack`, which succeeded and wrote `configs/package.json` and `configs/README.md`.
- Ran `pnpm before-commit`, which initially failed due to a missing dependency (`MODULE_NOT_FOUND: eslint-config-next`).
- Ran `pnpm install` to install missing deps and re-ran `pnpm before-commit`, and the full pipeline (`generate`, `test`, and `oxlint`) completed successfully with `130` tests passing and `oxlint` reporting `0` errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca00ca88048322b7c4e5009506e433)