### PR TITLE
chore: update repository namespace to popup-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "oxlint",
     "styleguide"
   ],
-  "homepage": "https://github.com/bartlangelaan/oxlint-config-presets#readme",
+  "homepage": "https://github.com/popup-plus/oxlint-config-presets#readme",
   "bugs": {
-    "url": "https://github.com/bartlangelaan/oxlint-config-presets/issues"
+    "url": "https://github.com/popup-plus/oxlint-config-presets/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bartlangelaan/oxlint-config-presets.git"
+    "url": "git+https://github.com/popup-plus/oxlint-config-presets.git"
   },
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
### Motivation
- Migrate package metadata to the new GitHub namespace `popup-plus` so published links and issue/CI references point to the new organization.

### Description
- Replace `homepage`, `bugs.url`, and `repository.url` in `package.json` from `bartlangelaan/...` to `popup-plus/...` and commit the change with message `chore: update GitHub namespace to popup-plus`.

### Testing
- Ran `pnpm before-commit` (which runs `pnpm generate`, `pnpm test`, and `pnpm oxlint`); all automated tests passed (130 tests OK) and `oxlint` reported 0 warnings/errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce249b6f0c83228aee11a31c129d71)