### PR TITLE
feat: generate .d.ts type definitions for TypeScript config file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 configs/package.json
 configs/README.md
+configs/**/*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 dist/
 configs/package.json
 configs/README.md
-configs/**/*.d.ts

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ You can also compose multiple presets. Later entries override earlier ones:
 If you use a [TypeScript config file](https://oxc.rs/docs/guide/usage/linter/config) (`oxlint.config.ts`), you can import presets directly. TypeScript type definitions are included for all presets:
 
 ```typescript
-import airbnb from "oxlint-config-presets/airbnb.json" with { type: "json" };
-import tsStrict from "oxlint-config-presets/@typescript-eslint/strict-type-checked.json" with { type: "json" };
-import { defineConfig } from "oxlint";
+import airbnb from 'oxlint-config-presets/airbnb.json' with { type: 'json' };
+import tsStrict from 'oxlint-config-presets/@typescript-eslint/strict-type-checked.json' with { type: 'json' };
+import { defineConfig } from 'oxlint';
 
 export default defineConfig({
   extends: [airbnb, tsStrict],

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ You can also compose multiple presets. Later entries override earlier ones:
 > Oxlint currently expects `extends` values to be **JSON file paths** relative to your config file.
 > For presets in this package, use `./node_modules/oxlint-config-presets/<config>.json`.
 
+### Usage with `oxlint.config.ts`
+
+If you use a [TypeScript config file](https://oxc.rs/docs/guide/usage/linter/config) (`oxlint.config.ts`), you can import presets directly. TypeScript type definitions are included for all presets:
+
+```typescript
+import airbnb from "oxlint-config-presets/airbnb.json" with { type: "json" };
+import tsStrict from "oxlint-config-presets/@typescript-eslint/strict-type-checked.json" with { type: "json" };
+import { defineConfig } from "oxlint";
+
+export default defineConfig({
+  extends: [airbnb, tsStrict],
+});
+```
+
+> [!NOTE]
+> Requires Node.js v22.18+ or v24+ for `with { type: "json" }` (import attributes) support.
+
 <!-- GENERATED CONFIGS START -->
 
 ## Available configs

--- a/configs/@antfu.json.d.ts
+++ b/configs/@antfu.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@eslint/all.json.d.ts
+++ b/configs/@eslint/all.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@eslint/recommended.json.d.ts
+++ b/configs/@eslint/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/all.json.d.ts
+++ b/configs/@typescript-eslint/all.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/recommended-type-checked.json.d.ts
+++ b/configs/@typescript-eslint/recommended-type-checked.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/recommended.json.d.ts
+++ b/configs/@typescript-eslint/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/strict-type-checked.json.d.ts
+++ b/configs/@typescript-eslint/strict-type-checked.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/strict.json.d.ts
+++ b/configs/@typescript-eslint/strict.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/stylistic-type-checked.json.d.ts
+++ b/configs/@typescript-eslint/stylistic-type-checked.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@typescript-eslint/stylistic.json.d.ts
+++ b/configs/@typescript-eslint/stylistic.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@vitest/all.json.d.ts
+++ b/configs/@vitest/all.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/@vitest/recommended.json.d.ts
+++ b/configs/@vitest/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/airbnb.json.d.ts
+++ b/configs/airbnb.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/airbnb/base.json.d.ts
+++ b/configs/airbnb/base.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/airbnb/hooks.json.d.ts
+++ b/configs/airbnb/hooks.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/airbnb/legacy.json.d.ts
+++ b/configs/airbnb/legacy.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/airbnb/whitespace.json.d.ts
+++ b/configs/airbnb/whitespace.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/alloy.json.d.ts
+++ b/configs/alloy.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/alloy/react.json.d.ts
+++ b/configs/alloy/react.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/alloy/typescript.json.d.ts
+++ b/configs/alloy/typescript.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/eslint.json.d.ts
+++ b/configs/eslint.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/eslint/base.json.d.ts
+++ b/configs/eslint/base.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/google.json.d.ts
+++ b/configs/google.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/hardcore.json.d.ts
+++ b/configs/hardcore.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import-x/errors.json.d.ts
+++ b/configs/import-x/errors.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import-x/recommended.json.d.ts
+++ b/configs/import-x/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import-x/stage-0.json.d.ts
+++ b/configs/import-x/stage-0.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import-x/typescript.json.d.ts
+++ b/configs/import-x/typescript.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import-x/warnings.json.d.ts
+++ b/configs/import-x/warnings.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import/errors.json.d.ts
+++ b/configs/import/errors.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import/recommended.json.d.ts
+++ b/configs/import/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import/stage-0.json.d.ts
+++ b/configs/import/stage-0.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import/typescript.json.d.ts
+++ b/configs/import/typescript.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/import/warnings.json.d.ts
+++ b/configs/import/warnings.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jest/all.json.d.ts
+++ b/configs/jest/all.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jest/recommended.json.d.ts
+++ b/configs/jest/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jest/style.json.d.ts
+++ b/configs/jest/style.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/default-expressions.json.d.ts
+++ b/configs/jsdoc/default-expressions.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/examples-and-default-expressions.json.d.ts
+++ b/configs/jsdoc/examples-and-default-expressions.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/examples.json.d.ts
+++ b/configs/jsdoc/examples.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-error.json.d.ts
+++ b/configs/jsdoc/recommended-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-tsdoc-error.json.d.ts
+++ b/configs/jsdoc/recommended-tsdoc-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-tsdoc.json.d.ts
+++ b/configs/jsdoc/recommended-tsdoc.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-typescript-error.json.d.ts
+++ b/configs/jsdoc/recommended-typescript-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-typescript-flavor-error.json.d.ts
+++ b/configs/jsdoc/recommended-typescript-flavor-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-typescript-flavor.json.d.ts
+++ b/configs/jsdoc/recommended-typescript-flavor.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended-typescript.json.d.ts
+++ b/configs/jsdoc/recommended-typescript.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsdoc/recommended.json.d.ts
+++ b/configs/jsdoc/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsx-a11y/recommended.json.d.ts
+++ b/configs/jsx-a11y/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/jsx-a11y/strict.json.d.ts
+++ b/configs/jsx-a11y/strict.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/n/recommended-module.json.d.ts
+++ b/configs/n/recommended-module.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/n/recommended-script.json.d.ts
+++ b/configs/n/recommended-script.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/n/recommended.json.d.ts
+++ b/configs/n/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/next/core-web-vitals.json.d.ts
+++ b/configs/next/core-web-vitals.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/next/recommended.json.d.ts
+++ b/configs/next/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/prettier.json.d.ts
+++ b/configs/prettier.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/problems.json.d.ts
+++ b/configs/problems.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/promise/recommended.json.d.ts
+++ b/configs/promise/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/react-perf/all.json.d.ts
+++ b/configs/react-perf/all.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/react-perf/recommended.json.d.ts
+++ b/configs/react-perf/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/react/all.json.d.ts
+++ b/configs/react/all.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/react/jsx-runtime.json.d.ts
+++ b/configs/react/jsx-runtime.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/react/recommended.json.d.ts
+++ b/configs/react/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/standard.json.d.ts
+++ b/configs/standard.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/essential.json.d.ts
+++ b/configs/vue/essential.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/recommended-error.json.d.ts
+++ b/configs/vue/recommended-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/recommended.json.d.ts
+++ b/configs/vue/recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/strongly-recommended-error.json.d.ts
+++ b/configs/vue/strongly-recommended-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/strongly-recommended.json.d.ts
+++ b/configs/vue/strongly-recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/vue2-essential.json.d.ts
+++ b/configs/vue/vue2-essential.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/vue2-recommended-error.json.d.ts
+++ b/configs/vue/vue2-recommended-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/vue2-recommended.json.d.ts
+++ b/configs/vue/vue2-recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/vue2-strongly-recommended-error.json.d.ts
+++ b/configs/vue/vue2-strongly-recommended-error.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/vue/vue2-strongly-recommended.json.d.ts
+++ b/configs/vue/vue2-strongly-recommended.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/wikimedia.json.d.ts
+++ b/configs/wikimedia.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/configs/xo.json.d.ts
+++ b/configs/xo.json.d.ts
@@ -1,0 +1,3 @@
+import type { OxlintConfig } from 'oxlint';
+declare const config: OxlintConfig;
+export default config;

--- a/package.json
+++ b/package.json
@@ -63,5 +63,13 @@
     "tsx": "^4.19.3",
     "typescript": "^6.0.2"
   },
+  "peerDependencies": {
+    "oxlint": ">=0.15.0"
+  },
+  "peerDependenciesMeta": {
+    "oxlint": {
+      "optional": true
+    }
+  },
   "packageManager": "pnpm@10.29.3"
 }

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -910,4 +910,21 @@ const updatedReadme =
 writeFileSync(readmePath, updatedReadme);
 console.log('\nWritten README.md');
 
+// ---- Generate .d.ts files for TypeScript config file support ----------------
+
+const dtsContent = [
+  'import type { OxlintConfig } from "oxlint";',
+  'declare const config: OxlintConfig;',
+  'export default config;',
+  '',
+].join('\n');
+
+for (const { config } of results) {
+  const dtsPath = join(configsDir, `${outputFor(config)}.d.ts`);
+  mkdirSync(dirname(dtsPath), { recursive: true });
+  writeFileSync(dtsPath, dtsContent);
+}
+
+console.log(`\nWritten ${results.length} .d.ts files`);
+
 console.log('\nDone.');

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -64,3 +64,11 @@ test('README.md is included', () => {
 test('pnpm-lock.yaml is not published', () => {
   assert.ok(!publishedFiles.includes('pnpm-lock.yaml'));
 });
+
+const expectedDtsFiles = expectedConfigs.map((f) => `${f}.d.ts`);
+
+for (const file of expectedDtsFiles) {
+  test(`${file} is included`, () => {
+    assert.ok(publishedFiles.includes(file), `missing from published files: ${file}`);
+  });
+}


### PR DESCRIPTION
> [!NOTE]
> An alternative approach using `exports` wildcard is proposed in #24.

## Summary

When importing JSON presets in `oxlint.config.ts`, TypeScript widens all JSON values to `string`, making them incompatible with `OxlintConfig` type expected by `extends`. This PR auto-generates `.d.ts` files alongside each JSON preset so that presets can be used directly without casts.

### Changes

- **scripts/generate.ts**: Generate a `.d.ts` file for each JSON preset after the main generation loop
- **package.json**: Add `oxlint` as an optional `peerDependency` (needed for `OxlintConfig` type)
- **configs/\*.json.d.ts**: Generated type definitions for all 73 presets
- **tests/publish.test.ts**: Verify `.d.ts` files are included in published package
- **README.md**: Add usage example for `oxlint.config.ts`

### Before

```typescript
// Cast required — JSON import values are widened to string
import preset from "oxlint-config-presets/airbnb.json" with { type: "json" };
import { type OxlintConfig, defineConfig } from "oxlint";

export default defineConfig({
  extends: [preset as unknown as OxlintConfig],
});
```

### After

```typescript
// No cast needed — .d.ts provides the correct type
import preset from "oxlint-config-presets/airbnb.json" with { type: "json" };
import { defineConfig } from "oxlint";

export default defineConfig({
  extends: [preset],
});
```

by ![Claude Code Badge](https://img.shields.io/badge/Claude_Code-D97757?logo=claude&logoColor=fff&style=flat-square)