### PR TITLE
chore: update oxlint-tsgolint to 0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "next": "^16.2.6",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
-    "oxlint-tsgolint": "^0.23.0",
+    "oxlint-tsgolint": "^0.24.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^8.2.0
-        version: 8.2.0(@next/eslint-plugin-next@16.2.6)(@typescript-eslint/rule-tester@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0))(eslint-plugin-react-refresh@0.5.2(eslint@10.3.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.3.0)(globals@17.7.0))(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.23.0))(typescript@6.0.3)
+        version: 8.2.0(@next/eslint-plugin-next@16.2.6)(@typescript-eslint/rule-tester@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0))(eslint-plugin-react-refresh@0.5.2(eslint@10.3.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.3.0)(globals@17.7.0))(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.24.0))(typescript@6.0.3)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0)
@@ -105,10 +105,10 @@ importers:
         version: 0.57.0
       oxlint:
         specifier: ^1.72.0
-        version: 1.72.0(oxlint-tsgolint@0.23.0)
+        version: 1.72.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: ^0.23.0
-        version: 0.23.0
+        specifier: ^0.24.0
+        version: 0.24.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1335,33 +1335,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
-    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
-    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
-    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
-    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+  '@oxlint-tsgolint/linux-x64@0.24.0':
+    resolution: {integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
-    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
-    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+  '@oxlint-tsgolint/win32-x64@0.24.0':
+    resolution: {integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==}
     cpu: [x64]
     os: [win32]
 
@@ -5875,8 +5875,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-tsgolint@0.23.0:
-    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+  oxlint-tsgolint@0.24.0:
+    resolution: {integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==}
     hasBin: true
 
   oxlint@1.72.0:
@@ -5989,6 +5989,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pkg-dir@5.0.0:
@@ -6951,11 +6955,11 @@ packages:
 
 snapshots:
 
-  '@antfu/eslint-config@8.2.0(@next/eslint-plugin-next@16.2.6)(@typescript-eslint/rule-tester@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0))(eslint-plugin-react-refresh@0.5.2(eslint@10.3.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.3.0)(globals@17.7.0))(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.23.0))(typescript@6.0.3)':
+  '@antfu/eslint-config@8.2.0(@next/eslint-plugin-next@16.2.6)(@typescript-eslint/rule-tester@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@10.3.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.3.0))(eslint-plugin-react-refresh@0.5.2(eslint@10.3.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.3.0)(globals@17.7.0))(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.24.0))(typescript@6.0.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.3.0
-      '@e18e/eslint-plugin': 0.3.0(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.23.0))
+      '@e18e/eslint-plugin': 0.3.0(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.24.0))
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@10.3.0)
       '@eslint/markdown': 8.0.1
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.3.0)
@@ -7344,12 +7348,12 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
-  '@e18e/eslint-plugin@0.3.0(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.23.0))':
+  '@e18e/eslint-plugin@0.3.0(eslint@10.3.0)(oxlint@1.72.0(oxlint-tsgolint@0.24.0))':
     dependencies:
       eslint-plugin-depend: 1.5.0(eslint@10.3.0)
     optionalDependencies:
       eslint: 10.3.0
-      oxlint: 1.72.0(oxlint-tsgolint@0.23.0)
+      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)
 
   '@ember-data/rfc395-data@0.0.4': {}
 
@@ -7966,22 +7970,22 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.57.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
+  '@oxlint-tsgolint/linux-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
+  '@oxlint-tsgolint/win32-x64@0.24.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.72.0':
@@ -8224,7 +8228,7 @@ snapshots:
     dependencies:
       '@putout/engine-loader': 13.1.1(putout@35.37.1(eslint@10.3.0)(typescript@6.0.3))
       once: 1.4.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       putout: 35.37.1(eslint@10.3.0)(typescript@6.0.3)
       try-to-catch: 3.0.1
 
@@ -8232,7 +8236,7 @@ snapshots:
     dependencies:
       '@putout/engine-loader': 15.4.1(putout@38.5.7(eslint@10.3.0)(typescript@6.0.3))
       once: 1.4.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       putout: 38.5.7(eslint@10.3.0)(typescript@6.0.3)
       try-to-catch: 3.0.1
 
@@ -9604,7 +9608,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@stylistic/eslint-plugin-ts@2.13.0(eslint@10.3.0)(typescript@5.9.3)':
     dependencies:
@@ -9623,7 +9627,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9636,7 +9640,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@stylistic/stylelint-plugin@3.1.3(stylelint@16.26.1(typescript@6.0.3))':
     dependencies:
@@ -12425,6 +12429,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   file-entry-cache@10.1.4:
     dependencies:
       flat-cache: 6.1.22
@@ -13683,16 +13691,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.24.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.23.0
-      '@oxlint-tsgolint/darwin-x64': 0.23.0
-      '@oxlint-tsgolint/linux-arm64': 0.23.0
-      '@oxlint-tsgolint/linux-x64': 0.23.0
-      '@oxlint-tsgolint/win32-arm64': 0.23.0
-      '@oxlint-tsgolint/win32-x64': 0.23.0
+      '@oxlint-tsgolint/darwin-arm64': 0.24.0
+      '@oxlint-tsgolint/darwin-x64': 0.24.0
+      '@oxlint-tsgolint/linux-arm64': 0.24.0
+      '@oxlint-tsgolint/linux-x64': 0.24.0
+      '@oxlint-tsgolint/win32-arm64': 0.24.0
+      '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -13713,7 +13721,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.72.0
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
-      oxlint-tsgolint: 0.23.0
+      oxlint-tsgolint: 0.24.0
 
   p-limit@2.3.0:
     dependencies:
@@ -13798,6 +13806,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pkg-dir@5.0.0:
     dependencies:
@@ -14056,7 +14066,7 @@ snapshots:
       is-relative: 1.0.0
       nano-memoize: 3.0.16
       once: 1.4.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       samadhi: 2.15.1(eslint@10.3.0)(putout@35.37.1(eslint@10.3.0)(typescript@6.0.3))(typescript@6.0.3)
       try-catch: 3.0.1
       try-to-catch: 3.0.1
@@ -14228,7 +14238,7 @@ snapshots:
       is-relative: 1.0.0
       nano-memoize: 3.0.16
       once: 1.4.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       try-catch: 3.0.1
       try-to-catch: 3.0.1
       wraptile: 3.0.0
@@ -14970,8 +14980,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@2.1.0: {}
 
@@ -15016,12 +15026,12 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@5.9.3):
     dependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       typescript: 5.9.3
 
   ts-declaration-location@1.0.7(typescript@6.0.3):
     dependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       typescript: 6.0.3
 
   ts-dedent@2.2.0: {}

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -408,7 +408,7 @@ const fromTsEslint =
   (name: string): (() => MigrateConfig[]) =>
   () => {
     const cfg = tsEslint.configs[name];
-    return (Array.isArray(cfg) ? cfg : [cfg]) as MigrateConfig[];
+    return Array.isArray(cfg) ? cfg : [cfg];
   };
 
 function isOldStyleConfig(entry: unknown): entry is OldStyleEslintConfig {
@@ -495,14 +495,14 @@ const fromEsmPluginPackagePresets = (
     .map(([name, cfg]) => ({
       sourcePackage,
       sourceConfig: name,
-      resolveConfig: () => (Array.isArray(cfg) ? cfg : [cfg]) as MigrateConfig[],
+      resolveConfig: () => (Array.isArray(cfg) ? cfg : [cfg]),
     }))
     .filter((cfg) => countRules(cfg.resolveConfig()) > 0);
 
 // eslint-config-xo uses flat config (ESM function returning an array of config objects).
 // We merge all rules from the returned entries to get the full effective rule set.
 const xoModule = await import('eslint-config-xo');
-const xoFn = xoModule.default as () => Array<{ rules?: ResolvedRules }>;
+const xoFn = xoModule.default;
 const fromXo = () => {
   return xoFn() as MigrateConfig[];
 };


### PR DESCRIPTION
## Summary

- Bumps `oxlint-tsgolint` from `^0.23.0` to `^0.24.0`
- Removes three now-unnecessary type assertions in `scripts/generate.ts` that the updated `no-unnecessary-type-assertion` rule correctly flags

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoucqyGtvUzZ3A3rzteCPz)_