### PR TITLE
Update TypeScript dependencies and add pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "eslint": "^10.8.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -70,7 +71,7 @@
     "oxlint": "^1.75.0",
     "oxlint-tsgolint": "^7.0.2001",
     "tsx": "^4.23.1",
-    "typescript": "^6.0.3"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "peerDependencies": {
     "oxlint": ">=0.15.0"
@@ -80,5 +81,10 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.29.3"
+  "packageManager": "pnpm@10.29.3",
+  "pnpm": {
+    "overrides": {
+      "typescript": "npm:@typescript/typescript6@^6.0.2"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  typescript: npm:@typescript/typescript6@^6.0.2
+
 patchedDependencies:
   '@oxlint/migrate@1.75.0':
     hash: 4c5a1edea8aecc9dfbfbbc67e7cc01ffbd06a9d126ca79f51782186230560263
@@ -15,7 +18,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^9.2.0
-        version: 9.2.0(@next/eslint-plugin-next@16.2.11)(@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.8.0))(eslint-plugin-react-refresh@0.5.3(eslint@10.8.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.8.0)(globals@17.7.0))(eslint@10.8.0)(oxlint@1.75.0(oxlint-tsgolint@7.0.2001))(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+        version: 9.2.0(@next/eslint-plugin-next@16.2.11)(@typescript-eslint/typescript-estree@8.65.0(@typescript/typescript6@6.0.2))(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(@vue/compiler-sfc@3.5.40)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.8.0))(eslint-plugin-react-refresh@0.5.3(eslint@10.8.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.8.0)(globals@17.7.0))(eslint@10.8.0)(oxlint@1.75.0(oxlint-tsgolint@7.0.2001))(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0)
@@ -27,10 +30,13 @@ importers:
         version: 26.1.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.65.0
-        version: 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+        version: 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/parser':
         specifier: ^8.65.0
-        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+        version: 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
       eslint:
         specifier: ^10.8.0
         version: 10.8.0
@@ -42,19 +48,19 @@ importers:
         version: 15.0.0(eslint-plugin-import@2.32.0)(eslint@10.8.0)
       eslint-config-alloy:
         specifier: ^5.1.2
-        version: 5.1.2(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-plugin-react@7.37.5(eslint@10.8.0))(eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)))(eslint@10.8.0)(typescript@6.0.3)(vue-eslint-parser@10.4.1(eslint@10.8.0))
+        version: 5.1.2(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-plugin-react@7.37.5(eslint@10.8.0))(eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0))
       eslint-config-eslint:
         specifier: ^14.0.0
-        version: 14.0.0(eslint@10.8.0)(typescript@6.0.3)
+        version: 14.0.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-config-google:
         specifier: ^0.14.0
         version: 0.14.0(eslint@10.8.0)
       eslint-config-hardcore:
         specifier: ^49.0.0
-        version: 49.0.0(@babel/core@8.0.1)(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)(globals@17.7.0)(prettier@3.9.6)(typescript@6.0.3)(vue-eslint-parser@10.4.1(eslint@10.8.0))
+        version: 49.0.0(@babel/core@8.0.1)(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)(globals@17.7.0)(prettier@3.9.6)(vue-eslint-parser@10.4.1(eslint@10.8.0))
       eslint-config-next:
         specifier: ^16.2.11
-        version: 16.2.11(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)(typescript@6.0.3)
+        version: 16.2.11(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.8.0)
@@ -63,22 +69,22 @@ importers:
         version: 10.0.1(eslint@10.8.0)
       eslint-config-standard:
         specifier: ^17.1.0
-        version: 17.1.0(eslint-plugin-import@2.32.0)(eslint-plugin-n@18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.8.0))(eslint@10.8.0)
+        version: 17.1.0(eslint-plugin-import@2.32.0)(eslint-plugin-n@18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2)))(eslint-plugin-promise@7.3.0(eslint@10.8.0))(eslint@10.8.0)
       eslint-config-wikimedia:
         specifier: ^0.32.4
-        version: 0.32.4(eslint@10.8.0)(typescript@6.0.3)
+        version: 0.32.4(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-config-xo:
         specifier: ^0.58.1
-        version: 0.58.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0)(eslint@10.8.0)(prettier@3.9.6)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+        version: 0.58.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0)(eslint@10.8.0)(prettier@3.9.6)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@10.8.0)
       eslint-plugin-n:
         specifier: ^18.2.2
-        version: 18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+        version: 18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))
       eslint-plugin-promise:
         specifier: ^7.3.0
         version: 7.3.0(eslint@10.8.0)
@@ -99,7 +105,7 @@ importers:
         version: eslint@8.57.1
       next:
         specifier: ^16.2.11
-        version: 16.2.11(@babel/core@8.0.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.11(@babel/core@8.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       oxfmt:
         specifier: ^0.60.0
         version: 0.60.0
@@ -113,8 +119,8 @@ importers:
         specifier: ^4.23.1
         version: 4.23.1
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
     publishDirectory: configs
 
 packages:
@@ -3244,6 +3250,130 @@ packages:
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
+
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -3386,20 +3516,20 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
-  '@vue/compiler-core@3.5.34':
-    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
 
-  '@vue/compiler-dom@3.5.34':
-    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
 
-  '@vue/compiler-sfc@3.5.34':
-    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
 
-  '@vue/compiler-ssr@3.5.34':
-    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
 
-  '@vue/shared@3.5.34':
-    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -6204,16 +6334,16 @@ packages:
   rambda@7.5.0:
     resolution: {integrity: sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==}
 
-  react-dom@19.2.6:
-    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.8
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react@19.2.6:
-    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   read-pkg-up@7.0.1:
@@ -6826,14 +6956,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   ufo@1.6.4:
@@ -7071,7 +7201,7 @@ packages:
 
 snapshots:
 
-  '@antfu/eslint-config@9.2.0(@next/eslint-plugin-next@16.2.11)(@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.8.0))(eslint-plugin-react-refresh@0.5.3(eslint@10.8.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.8.0)(globals@17.7.0))(eslint@10.8.0)(oxlint@1.75.0(oxlint-tsgolint@7.0.2001))(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)':
+  '@antfu/eslint-config@9.2.0(@next/eslint-plugin-next@16.2.11)(@typescript-eslint/typescript-estree@8.65.0(@typescript/typescript6@6.0.2))(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(@vue/compiler-sfc@3.5.40)(eslint-plugin-jsx-a11y@6.10.2(eslint@10.8.0))(eslint-plugin-react-refresh@0.5.3(eslint@10.8.0))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.8.0)(globals@17.7.0))(eslint@10.8.0)(oxlint@1.75.0(oxlint-tsgolint@7.0.2001))(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.7.0
@@ -7079,9 +7209,9 @@ snapshots:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.8.0)
       '@eslint/markdown': 8.0.3
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.0)
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
-      '@vitest/eslint-plugin': 1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@vitest/eslint-plugin': 1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       ansis: 4.3.1
       cac: 7.0.0
       eslint: 10.8.0
@@ -7089,21 +7219,21 @@ snapshots:
       eslint-flat-config-utils: 3.2.0
       eslint-merge-processors: 2.0.0(eslint@10.8.0)
       eslint-plugin-antfu: 3.2.3(eslint@10.8.0)
-      eslint-plugin-command: 3.5.3(@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
+      eslint-plugin-command: 3.5.3(@typescript-eslint/typescript-estree@8.65.0(@typescript/typescript6@6.0.2))(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
       eslint-plugin-import-lite: 0.6.0(eslint@10.8.0)
       eslint-plugin-jsdoc: 63.2.2(eslint@10.8.0)
       eslint-plugin-jsonc: 3.3.0(eslint@10.8.0)
-      eslint-plugin-n: 18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+      eslint-plugin-n: 18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))
       eslint-plugin-no-only-tests: 3.4.0
-      eslint-plugin-perfectionist: 5.10.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-perfectionist: 5.10.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-pnpm: 1.7.0(eslint@10.8.0)
       eslint-plugin-regexp: 3.1.1(eslint@10.8.0)
       eslint-plugin-toml: 1.4.0(eslint@10.8.0)
       eslint-plugin-unicorn: 72.0.0(eslint@10.8.0)
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
-      eslint-plugin-vue: 10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
+      eslint-plugin-vue: 10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0))
       eslint-plugin-yml: 3.6.0(eslint@10.8.0)
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.34)(eslint@10.8.0)
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.40)(eslint@10.8.0)
       globals: 17.7.0
       local-pkg: 1.2.1
       parse-gitignore: 2.0.0
@@ -8234,10 +8364,10 @@ snapshots:
       oxc-parser: 0.139.0
       tinyglobby: 0.2.17
 
-  '@phenomnomnominal/tsquery@5.0.1(typescript@6.0.3)':
+  '@phenomnomnominal/tsquery@5.0.1(@typescript/typescript6@6.0.2)':
     dependencies:
       esquery: 1.7.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   '@pkgr/core@0.1.2': {}
 
@@ -8266,17 +8396,17 @@ snapshots:
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
-  '@putout/cli-choose-formatter@4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/cli-choose-formatter@4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/cli-choose': 2.0.0
       find-up: 7.0.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/cli-choose-formatter@4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/cli-choose-formatter@4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/cli-choose': 2.0.0
       find-up: 7.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
   '@putout/cli-choose@2.0.0':
     dependencies:
@@ -8295,14 +8425,14 @@ snapshots:
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
-  '@putout/cli-process-file@2.4.0(eslint@10.8.0)(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/cli-process-file@2.4.0(eslint@10.8.0)(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/eslint': 4.1.0(eslint@10.8.0)
-      '@putout/formatter-eslint': 2.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-eslint': 2.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       deepmerge: 4.3.1
       once: 1.4.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
-      samadhi: 2.15.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      samadhi: 2.15.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       try-catch: 3.0.1
       try-to-catch: 3.0.1
     transitivePeerDependencies:
@@ -8352,31 +8482,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/engine-loader@13.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-loader@13.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/engine-parser': 10.8.0
       diff-match-patch: 1.0.5
       nano-memoize: 3.0.16
       once: 1.4.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
-  '@putout/engine-loader@15.4.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-loader@15.4.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       diff-match-patch: 1.0.5
       nano-memoize: 3.0.16
       once: 1.4.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
-  '@putout/engine-loader@15.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-loader@15.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       diff-match-patch: 1.0.5
       nano-memoize: 3.0.16
       once: 1.4.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
@@ -8404,79 +8534,79 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/engine-processor@11.4.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-processor@11.4.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/engine-loader': 13.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 13.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       once: 1.4.0
       picomatch: 4.0.5
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-to-catch: 3.0.1
 
-  '@putout/engine-processor@13.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-processor@13.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/engine-loader': 15.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 15.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       once: 1.4.0
       picomatch: 4.0.5
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-to-catch: 3.0.1
 
-  '@putout/engine-reporter@1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-reporter@1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/cli-choose-formatter': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/cli-choose-formatter': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/cli-keypress': 2.0.0
-      '@putout/engine-loader': 13.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 13.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       fullstore: 3.0.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
-  '@putout/engine-reporter@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-reporter@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/cli-choose-formatter': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/cli-choose-formatter': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/cli-keypress': 2.0.0
-      '@putout/engine-loader': 15.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 15.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       fullstore: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       try-to-catch: 3.0.1
 
-  '@putout/engine-runner@21.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-runner@21.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/compare': 14.7.2
       '@putout/engine-parser': 10.8.0
       '@putout/operate': 12.18.0
-      '@putout/operator-declare': 9.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-declare': 9.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
-      '@putout/plugin-filesystem': 5.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/plugin-filesystem': 5.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       debug: 4.4.3
       fullstore: 3.0.0
       jessy: 3.1.1
       nessy: 4.0.0
       once: 1.4.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       wraptile: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/engine-runner@23.6.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/engine-runner@23.6.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/compare': 16.0.3
       '@putout/engine-parser': 12.6.0
       '@putout/operate': 13.5.0
-      '@putout/operator-declare': 11.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-declare': 11.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
-      '@putout/plugin-filesystem': 8.3.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/plugin-filesystem': 8.3.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       debug: 4.4.3
       fullstore: 3.0.0
       jessy: 4.1.0
       nessy: 5.3.0
       once: 1.4.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
       wraptile: 3.0.0
     transitivePeerDependencies:
@@ -8501,145 +8631,145 @@ snapshots:
       once: 1.4.0
       try-to-catch: 3.0.1
 
-  '@putout/formatter-codeframe@7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-codeframe@7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
-      '@putout/formatter-json': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-json': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       table: 6.9.0
 
-  '@putout/formatter-codeframe@8.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-codeframe@8.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
-      '@putout/formatter-json': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-json': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       table: 6.9.0
 
-  '@putout/formatter-dump@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-dump@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-json': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-json': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       table: 6.9.0
 
-  '@putout/formatter-dump@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-dump@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-json': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-json': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       table: 6.9.0
 
-  '@putout/formatter-eslint@2.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-eslint@2.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-json': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/formatter-json': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-frame@6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-frame@6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-codeframe': 7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/formatter-codeframe': 7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-frame@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-frame@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-codeframe': 8.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/formatter-codeframe': 8.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-json-lines@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-json-lines@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-json-lines@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-json-lines@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-json@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-json@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-json@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-json@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-memory@4.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-memory@4.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-dump': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
       cli-progress: 3.12.0
       format-io: 2.0.0
       montag: 1.2.1
       once: 1.4.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-memory@4.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-memory@4.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-dump': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
       cli-progress: 3.12.0
       format-io: 2.0.0
       montag: 1.2.1
       once: 1.4.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-progress-bar@4.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-progress-bar@4.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-dump': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
       cli-progress: 3.12.0
       once: 1.4.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-progress-bar@4.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-progress-bar@4.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-dump': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
       cli-progress: 3.12.0
       once: 1.4.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-progress@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-progress@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/formatter-dump': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-progress@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-progress@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/formatter-dump': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/formatter-stream@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      chalk: 5.6.2
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-      table: 6.9.0
-
-  '@putout/formatter-stream@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-stream@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       chalk: 5.6.2
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       table: 6.9.0
 
-  '@putout/formatter-time@3.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-stream@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      chalk: 5.6.2
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      table: 6.9.0
+
+  '@putout/formatter-time@3.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      '@putout/formatter-dump': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
       cli-progress: 3.12.0
       format-io: 2.0.0
       montag: 1.2.1
       once: 1.4.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       timer-node: 5.0.9
 
-  '@putout/formatter-time@3.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/formatter-time@3.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/formatter-dump': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-dump': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       chalk: 5.6.2
       cli-progress: 3.12.0
       format-io: 2.0.0
       montag: 1.2.1
       once: 1.4.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       timer-node: 5.0.9
 
   '@putout/git-status-porcelain@3.0.0': {}
@@ -8652,58 +8782,58 @@ snapshots:
     dependencies:
       '@putout/babel': 3.2.0
 
-  '@putout/operator-add-args@10.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-add-args@10.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/compare': 16.0.3
       '@putout/engine-parser': 12.6.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/operator-add-args@8.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-add-args@8.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/compare': 14.7.2
       '@putout/engine-parser': 10.8.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/operator-declare@11.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-declare@11.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/compare': 16.0.3
       '@putout/engine-parser': 12.6.0
       '@putout/operate': 13.5.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/operator-declare@9.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-declare@9.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/compare': 14.7.2
       '@putout/engine-parser': 10.8.0
       '@putout/operate': 12.18.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/operator-filesystem@4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-filesystem@4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/operate': 12.18.0
       fullstore: 3.0.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
 
-  '@putout/operator-filesystem@6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-filesystem@6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/operate': 13.5.0
       fullstore: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
 
   '@putout/operator-ignore@1.3.0':
@@ -8722,890 +8852,890 @@ snapshots:
 
   '@putout/operator-keyword@2.2.0': {}
 
-  '@putout/operator-match-files@3.5.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-match-files@3.5.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/engine-parser': 10.8.0
-      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/operator-match-files@6.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-match-files@6.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/engine-parser': 12.6.0
-      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
   '@putout/operator-parens@1.2.0':
     dependencies:
       '@putout/babel': 3.2.0
 
-  '@putout/operator-regexp@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-regexp@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       regexp-tree: 0.1.27
 
-  '@putout/operator-regexp@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-regexp@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       regexp-tree: 0.1.27
 
-  '@putout/operator-rename-files@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-rename-files@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/operator-rename-files@2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/operator-rename-files@2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-arrow@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-arrow@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-at@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-at@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-at@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-at@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-destructuring@7.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-destructuring@7.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-destructuring@8.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-destructuring@8.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-dot-notation@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-dot-notation@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-dot-notation@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-dot-notation@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-early-return@3.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-early-return@3.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-flat-map@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-flat-map@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-flat-map@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-flat-map@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-optional-chaining@6.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-optional-chaining@6.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-overrides@1.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-overrides@1.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-overrides@2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-overrides@2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-shorthand-properties@5.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-shorthand-properties@5.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-shorthand-properties@6.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-shorthand-properties@6.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-starts-with@1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-starts-with@1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-starts-with@1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-starts-with@1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-template-literals@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-template-literals@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-apply-template-literals@4.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-apply-template-literals@4.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-browserlist@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-browserlist@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-browserlist@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-browserlist@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-conditions@4.4.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-conditions@4.4.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-conditions@7.3.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-conditions@7.3.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-apply-to-spread@4.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-apply-to-spread@4.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-apply-to-spread@4.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-apply-to-spread@4.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-arguments-to-rest@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-arguments-to-rest@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-arguments-to-rest@3.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-arguments-to-rest@3.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-array-copy-to-slice@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-array-copy-to-slice@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-array-copy-to-slice@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-array-copy-to-slice@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-assignment-to-arrow-function@1.2.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-assignment-to-arrow-function@1.2.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-assignment-to-arrow-function@1.2.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-assignment-to-arrow-function@1.2.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-assignment-to-comparison@2.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-assignment-to-comparison@2.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-assignment-to-comparison@2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-assignment-to-comparison@2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-assignment-to-declaration@1.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-assignment-to-declaration@1.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-assignment-to-declaration@2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-assignment-to-declaration@2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-concat-to-flat@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-concat-to-flat@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-concat-to-flat@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-concat-to-flat@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-const-to-let@2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-const-to-let@2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-const-to-let@4.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-const-to-let@4.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-expression-to-params@1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-expression-to-params@1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-index-of-to-includes@2.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-index-of-to-includes@2.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-index-of-to-includes@2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-index-of-to-includes@2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-label-to-object@1.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-label-to-object@1.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-object-assign-to-merge-spread@6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-object-assign-to-merge-spread@6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-object-assign-to-merge-spread@6.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-object-assign-to-merge-spread@6.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-object-entries-to-array-entries@3.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-object-entries-to-array-entries@3.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-object-entries-to-array-entries@3.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-object-entries-to-array-entries@3.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-optional-to-logical@3.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-optional-to-logical@3.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-quotes-to-backticks@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-quotes-to-backticks@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-quotes-to-backticks@4.0.3(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-quotes-to-backticks@4.0.3(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-template-to-string@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-template-to-string@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-template-to-string@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-template-to-string@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-to-arrow-function@4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-to-arrow-function@4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-convert-to-arrow-function@4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-convert-to-arrow-function@4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-coverage@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-coverage@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-coverage@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-coverage@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-declare-before-reference@4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-declare-before-reference@4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-declare-before-reference@6.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-declare-before-reference@6.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-declare-imports-first@2.1.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-declare-imports-first@2.1.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-declare@4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-declare@4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-declare@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-declare@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-eslint@12.4.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-eslint@12.4.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-eslint@8.13.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-eslint@8.13.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-esm@2.3.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-esm@2.3.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       parse-import-specifiers: 1.0.3
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-extract-keywords-from-variables@2.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-extract-keywords-from-variables@2.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-extract-object-properties@9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-extract-object-properties@9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-extract-object-properties@9.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-extract-object-properties@9.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-extract-sequence-expressions@3.5.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-extract-sequence-expressions@3.5.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-extract-sequence-expressions@3.5.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-extract-sequence-expressions@3.5.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-filesystem@5.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-filesystem@5.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/operate': 12.18.0
-      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-filesystem@8.3.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-filesystem@8.3.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/operate': 13.5.0
-      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-for-of@6.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-for-of@6.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-for-of@8.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-for-of@8.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-generators@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      fullstore: 3.0.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-generators@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-generators@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       fullstore: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-github@12.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-github@14.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-gitignore@6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-gitignore@6.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-group-imports-by-source@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-labels@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-generators@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       fullstore: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-logical-expressions@6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-github@12.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-logical-expressions@7.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-github@14.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-madrun@18.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-gitignore@6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-madrun@20.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-gitignore@6.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-math@2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-group-imports-by-source@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-math@3.4.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-labels@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      fullstore: 3.0.0
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-maybe@2.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-logical-expressions@6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-maybe@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-logical-expressions@7.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-merge-destructuring-properties@10.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-madrun@18.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-merge-destructuring-properties@9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-madrun@20.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-merge-duplicate-functions@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-math@2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-merge-duplicate-functions@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-math@3.4.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-merge-duplicate-imports@11.0.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-maybe@2.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-montag@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-maybe@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-montag@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-merge-destructuring-properties@10.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-new@3.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-merge-destructuring-properties@9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-new@3.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-merge-duplicate-functions@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-nodejs@11.11.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-merge-duplicate-functions@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-merge-duplicate-imports@11.0.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-montag@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-montag@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-new@3.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-new@3.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-nodejs@11.11.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       just-camel-case: 6.2.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-nodejs@14.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-nodejs@14.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       just-camel-case: 6.2.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-npmignore@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-npmignore@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-npmignore@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-npmignore@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-optional-chaining@1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-optional-chaining@1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-package-json@7.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-package-json@7.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-package-json@9.1.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-package-json@9.1.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-parens@2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-parens@2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-promises@15.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      fullstore: 3.0.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-promises@16.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-promises@15.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       fullstore: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-putout-config@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-putout-config@8.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-putout@20.10.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-promises@16.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       fullstore: 3.0.0
-      just-camel-case: 6.2.0
-      parse-import-specifiers: 1.0.3
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-      try-catch: 3.0.1
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-putout@23.16.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-putout-config@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-putout-config@8.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-putout@20.10.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       fullstore: 3.0.0
       just-camel-case: 6.2.0
       parse-import-specifiers: 1.0.3
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
 
-  '@putout/plugin-regexp@10.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-putout@23.16.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      fullstore: 3.0.0
+      just-camel-case: 6.2.0
+      parse-import-specifiers: 1.0.3
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      try-catch: 3.0.1
+
+  '@putout/plugin-regexp@10.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       regexp-tree: 0.1.27
       try-catch: 3.0.1
 
-  '@putout/plugin-regexp@9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-regexp@9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       regexp-tree: 0.1.27
       try-catch: 3.0.1
 
-  '@putout/plugin-remove-console@6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-console@6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-console@6.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-console@6.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-constant-conditions@4.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-constant-conditions@4.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-constant-conditions@4.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-constant-conditions@4.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-debugger@7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-debugger@7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-debugger@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-debugger@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-duplicate-case@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-duplicate-case@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-duplicate-case@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-duplicate-case@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-duplicate-keys@5.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
-    dependencies:
-      fullstore: 3.0.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-
-  '@putout/plugin-remove-duplicate-keys@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-duplicate-keys@5.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       fullstore: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-empty@12.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-duplicate-keys@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      fullstore: 3.0.0
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-empty@14.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-empty@12.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-iife@4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-empty@14.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-iife@4.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-iife@4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-nested-blocks@6.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-iife@4.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-nested-blocks@8.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-nested-blocks@6.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-quotes-from-import-assertions@1.0.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-nested-blocks@8.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unreachable-code@1.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-quotes-from-import-assertions@1.0.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unreachable-code@2.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unreachable-code@1.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unreferenced-variables@4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unreachable-code@2.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unreferenced-variables@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unreferenced-variables@4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-expressions@11.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unreferenced-variables@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-expressions@9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-expressions@11.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-for-of-variables@3.0.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-expressions@9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-for-of-variables@3.0.3(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-for-of-variables@3.0.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-labels@1.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-for-of-variables@3.0.3(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-private-fields@2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-labels@1.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-private-fields@3.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-private-fields@2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-variables@12.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-private-fields@3.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-unused-variables@9.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-variables@12.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-arguments@11.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-unused-variables@9.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-arguments@8.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-arguments@11.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-array-constructor@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-arguments@8.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-array-constructor@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-array-constructor@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-array-entries@1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-array-constructor@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-array-entries@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-array-entries@1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-array@1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-array-entries@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-array@1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-array@1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-assign@1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-array@1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-assign@1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-assign@1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-constructor@1.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-assign@1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-constructor@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-constructor@1.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-continue@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-constructor@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-continue@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-continue@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-delete@1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-continue@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-escape@6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-delete@1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
+    dependencies:
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+
+  '@putout/plugin-remove-useless-escape@6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       emoji-regex: 10.6.0
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-escape@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-escape@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       emoji-regex: 10.6.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-functions@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-functions@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-functions@4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-functions@4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-map@1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-map@1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-map@1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-map@1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-operand@2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-operand@2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-operand@2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-operand@2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-push@1.0.3(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-push@1.0.3(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-replace@1.0.4(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-replace@1.0.4(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-replace@1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-replace@1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-return@7.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-return@7.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-spread@11.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-spread@11.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-spread@12.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-spread@12.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-template-expressions@2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-template-expressions@2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-template-expressions@2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-template-expressions@2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-variables@11.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-variables@11.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-remove-useless-variables@13.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-remove-useless-variables@13.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-return@1.1.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-return@1.1.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-reuse-duplicate-init@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-reuse-duplicate-init@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-reuse-duplicate-init@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-reuse-duplicate-init@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-simplify-assignment@3.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-simplify-assignment@3.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-simplify-assignment@3.1.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-simplify-assignment@3.1.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-simplify-boolean-return@2.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-simplify-boolean-return@2.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-simplify-ternary@7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-simplify-ternary@7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-simplify-ternary@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-simplify-ternary@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-sort-imports-by-specifiers@1.1.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-sort-imports-by-specifiers@1.1.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       parse-import-specifiers: 1.0.3
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-assignment-expressions@1.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-assignment-expressions@1.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-assignment-expressions@2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-assignment-expressions@2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-call-with-destructuring@1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-call-with-destructuring@1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-nested-destructuring@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-nested-destructuring@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-nested-destructuring@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-nested-destructuring@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-variable-declarations@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-variable-declarations@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-split-variable-declarations@4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-split-variable-declarations@4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-tape@14.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-tape@14.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-tape@17.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-tape@17.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-try-catch@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-try-catch@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-try-catch@4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-try-catch@4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-types@4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-types@4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-types@7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-types@7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-typescript@11.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-typescript@11.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-typescript@7.4.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-typescript@7.4.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-webpack@3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-webpack@3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/plugin-webpack@3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/plugin-webpack@3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
   '@putout/printer@13.4.1':
     dependencies:
@@ -9633,45 +9763,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@putout/processor-css@10.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@putout/processor-css@10.0.1(@typescript/typescript6@6.0.2)(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      '@stylistic/stylelint-plugin': 3.1.3(stylelint@16.26.1(typescript@6.0.3))
+      '@stylistic/stylelint-plugin': 3.1.3(stylelint@16.26.1(@typescript/typescript6@6.0.2))
       align-spaces: 2.0.0
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.2)
       deepmerge: 4.3.1
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
-      stylelint: 16.26.1(typescript@6.0.3)
-      stylelint-config-standard: 37.0.0(stylelint@16.26.1(typescript@6.0.3))
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      stylelint: 16.26.1(@typescript/typescript6@6.0.2)
+      stylelint-config-standard: 37.0.0(stylelint@16.26.1(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@putout/processor-css@9.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))(typescript@6.0.3)':
+  '@putout/processor-css@9.2.0(@typescript/typescript6@6.0.2)(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       align-spaces: 1.0.4
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.2)
       deepmerge: 4.3.1
       prettier: 3.9.6
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-      stylelint: 16.26.1(typescript@6.0.3)
-      stylelint-config-standard: 37.0.0(stylelint@16.26.1(typescript@6.0.3))
-      stylelint-prettier: 5.0.3(prettier@3.9.6)(stylelint@16.26.1(typescript@6.0.3))
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      stylelint: 16.26.1(@typescript/typescript6@6.0.2)
+      stylelint-config-standard: 37.0.0(stylelint@16.26.1(@typescript/typescript6@6.0.2))
+      stylelint-prettier: 5.0.3(prettier@3.9.6)(stylelint@16.26.1(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@putout/processor-filesystem@4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/processor-filesystem@4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/cli-filesystem': 2.1.0
-      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
     transitivePeerDependencies:
       - putout
 
-  '@putout/processor-filesystem@5.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/processor-filesystem@5.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
       '@putout/cli-filesystem': 2.1.0
-      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-json': 2.2.0
     transitivePeerDependencies:
       - putout
@@ -9680,13 +9810,13 @@ snapshots:
     dependencies:
       '@putout/operator-json': 2.2.0
 
-  '@putout/processor-javascript@5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/processor-javascript@5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  '@putout/processor-javascript@5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))':
+  '@putout/processor-javascript@5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))':
     dependencies:
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
   '@putout/processor-json@9.0.0':
     dependencies:
@@ -9735,21 +9865,21 @@ snapshots:
 
   '@rviscomi/capo.js@2.1.0': {}
 
-  '@shopify/eslint-plugin@45.0.0(@babel/core@8.0.1)(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)(prettier@3.9.6)(typescript@6.0.3)':
+  '@shopify/eslint-plugin@45.0.0(@babel/core@8.0.1)(@typescript/typescript6@6.0.2)(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)(prettier@3.9.6)':
     dependencies:
       '@babel/eslint-parser': 7.29.7(@babel/core@8.0.1)(eslint@10.8.0)
       '@babel/eslint-plugin': 7.29.7(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(eslint@10.8.0)
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       change-case: 4.1.2
       common-tags: 1.8.2
       doctrine: 2.1.0
       eslint: 10.8.0
       eslint-config-prettier: 9.1.2(eslint@10.8.0)
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@10.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
-      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
+      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@10.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.8.0)
       eslint-plugin-node: 11.1.0(eslint@10.8.0)
@@ -9792,9 +9922,9 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.5
 
-  '@stylistic/eslint-plugin-ts@2.13.0(eslint@10.8.0)(typescript@5.9.3)':
+  '@stylistic/eslint-plugin-ts@2.13.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -9802,9 +9932,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@stylistic/eslint-plugin@3.1.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@stylistic/eslint-plugin@3.1.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -9824,7 +9954,7 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.5
 
-  '@stylistic/stylelint-plugin@3.1.3(stylelint@16.26.1(typescript@6.0.3))':
+  '@stylistic/stylelint-plugin@3.1.3(stylelint@16.26.1(@typescript/typescript6@6.0.2))':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
@@ -9834,7 +9964,7 @@ snapshots:
       postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
       style-search: 0.1.0
-      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint: 16.26.1(@typescript/typescript6@6.0.2)
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9895,97 +10025,79 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       debug: 4.4.3
       eslint: 10.8.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@6.0.3)
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@5.9.3))(eslint@10.8.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@10.8.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 10.8.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 10.8.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@6.0.3)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/utils': 8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/visitor-keys': 8.54.0
       eslint: 10.8.0
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/type-utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       '@typescript-eslint/visitor-keys': 8.65.0
       eslint: 10.8.0
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@2.34.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/experimental-utils@2.34.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@types/json-schema': 7.0.15
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 2.34.0(@typescript/typescript6@6.0.2)
       eslint: 10.8.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
@@ -9993,100 +10105,78 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/experimental-utils@5.62.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/experimental-utils@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@5.62.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(@typescript/typescript6@6.0.2)
       debug: 4.4.3
       eslint: 10.8.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3
       eslint: 10.8.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3
-      eslint: 10.8.0
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.54.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.54.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
       eslint: 10.8.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       eslint: 10.8.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.54.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.54.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/tsconfig-utils': 8.54.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/types': 8.54.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.65.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -10110,75 +10200,59 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.54.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.54.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
-      typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@5.62.0(eslint@10.8.0)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       debug: 4.4.3
       eslint: 10.8.0
-      tsutils: 3.21.0(typescript@6.0.3)
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@10.8.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       debug: 4.4.3
       eslint: 10.8.0
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@10.8.0)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.8.0
-      ts-api-utils: 1.4.3(typescript@6.0.3)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@8.54.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.54.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       debug: 4.4.3
       eslint: 10.8.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       debug: 4.4.3
       eslint: 10.8.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -10190,7 +10264,7 @@ snapshots:
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@2.34.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@2.34.0(@typescript/typescript6@6.0.2)':
     dependencies:
       debug: 4.4.3
       eslint-visitor-keys: 1.3.0
@@ -10198,13 +10272,13 @@ snapshots:
       is-glob: 4.0.3
       lodash: 4.18.1
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@6.0.3)
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(@typescript/typescript6@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -10212,13 +10286,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@6.0.3)
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(@typescript/typescript6@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -10227,80 +10301,50 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.5
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.54.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.9
-      semver: 7.8.5
-      ts-api-utils: 1.4.3(typescript@6.0.3)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.54.0(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.54.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.54.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.54.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
       minimatch: 9.0.9
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.65.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@5.62.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(@typescript/typescript6@6.0.2)
       eslint: 10.8.0
       eslint-scope: 5.1.1
       semver: 7.8.5
@@ -10308,58 +10352,36 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@10.8.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.2)
       eslint: 10.8.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@10.8.0)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
-      eslint: 10.8.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@8.54.0(eslint@10.8.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/typescript-estree': 8.54.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.54.0(@typescript/typescript6@6.0.2)
       eslint: 10.8.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(@typescript/typescript6@6.0.2)
       eslint: 10.8.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
-      '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      eslint: 10.8.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -10382,6 +10404,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -10455,50 +10541,50 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
+  '@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      typescript: 6.0.3
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@vscode/l10n@0.0.18': {}
 
-  '@vue/compiler-core@3.5.34':
+  '@vue/compiler-core@3.5.40':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/shared': 3.5.34
+      '@vue/shared': 3.5.40
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.34':
+  '@vue/compiler-dom@3.5.40':
     dependencies:
-      '@vue/compiler-core': 3.5.34
-      '@vue/shared': 3.5.34
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
 
-  '@vue/compiler-sfc@3.5.34':
+  '@vue/compiler-sfc@3.5.40':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue/compiler-core': 3.5.34
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.23
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.34':
+  '@vue/compiler-ssr@3.5.40':
     dependencies:
-      '@vue/compiler-dom': 3.5.34
-      '@vue/shared': 3.5.34
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
 
-  '@vue/shared@3.5.34': {}
+  '@vue/shared@3.5.40': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -10812,14 +10898,14 @@ snapshots:
     dependencies:
       browserslist: 4.28.7
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
+  cosmiconfig@9.0.2(@typescript/typescript6@6.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11134,7 +11220,7 @@ snapshots:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 10.8.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
       object.assign: 4.1.7
       object.entries: 1.1.9
       semver: 6.3.1
@@ -11143,31 +11229,31 @@ snapshots:
     dependencies:
       eslint: 10.8.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@10.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.8.0)
       eslint-plugin-react: 7.37.5(eslint@10.8.0)
       eslint-plugin-react-hooks: 7.1.1(eslint@10.8.0)
       object.assign: 4.1.7
       object.entries: 1.1.9
 
-  eslint-config-alloy@5.1.2(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-plugin-react@7.37.5(eslint@10.8.0))(eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)))(eslint@10.8.0)(typescript@6.0.3)(vue-eslint-parser@10.4.1(eslint@10.8.0)):
+  eslint-config-alloy@5.1.2(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-plugin-react@7.37.5(eslint@10.8.0))(eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)):
     dependencies:
       eslint: 10.8.0
     optionalDependencies:
       '@babel/eslint-parser': 7.29.7(@babel/core@8.0.1)(eslint@10.8.0)
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-react: 7.37.5(eslint@10.8.0)
-      eslint-plugin-vue: 10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0))
-      typescript: 6.0.3
+      eslint-plugin-vue: 10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0))
+      typescript: '@typescript/typescript6@6.0.2'
       vue-eslint-parser: 10.4.1(eslint@10.8.0)
 
-  eslint-config-eslint@14.0.0(eslint@10.8.0)(typescript@6.0.3):
+  eslint-config-eslint@14.0.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.8.0)
       '@eslint/js': 10.0.1(eslint@10.8.0)
       eslint-plugin-jsdoc: 62.9.0(eslint@10.8.0)
-      eslint-plugin-n: 17.24.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-n: 17.24.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-regexp: 2.10.0(eslint@10.8.0)
       eslint-plugin-unicorn: 52.0.0(eslint@10.8.0)
     optionalDependencies:
@@ -11185,41 +11271,41 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  eslint-config-hardcore@49.0.0(@babel/core@8.0.1)(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)(globals@17.7.0)(prettier@3.9.6)(typescript@6.0.3)(vue-eslint-parser@10.4.1(eslint@10.8.0)):
+  eslint-config-hardcore@49.0.0(@babel/core@8.0.1)(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)(globals@17.7.0)(prettier@3.9.6)(vue-eslint-parser@10.4.1(eslint@10.8.0)):
     dependencies:
       '@arthurgeron/eslint-plugin-react-usememo': 2.5.0(eslint@10.8.0)
       '@html-eslint/eslint-plugin': 0.44.0(eslint@10.8.0)
       '@microsoft/eslint-plugin-sdl': 0.2.2(eslint@10.8.0)
-      '@putout/plugin-apply-shorthand-properties': 5.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@shopify/eslint-plugin': 45.0.0(@babel/core@8.0.1)(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)(prettier@3.9.6)(typescript@6.0.3)
-      '@stylistic/eslint-plugin': 3.1.0(eslint@10.8.0)(typescript@6.0.3)
+      '@putout/plugin-apply-shorthand-properties': 5.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@shopify/eslint-plugin': 45.0.0(@babel/core@8.0.1)(@typescript/typescript6@6.0.2)(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)(prettier@3.9.6)
+      '@stylistic/eslint-plugin': 3.1.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-config-prettier: 10.1.8(eslint@10.8.0)
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.32.0)
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
       eslint-plugin-array-func: 4.0.0(eslint@10.8.0)
       eslint-plugin-compat: 6.2.1(eslint@10.8.0)
       eslint-plugin-decorator-position: 6.1.1(@babel/eslint-parser@7.29.7(@babel/core@8.0.1)(eslint@10.8.0))(eslint@10.8.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@10.8.0)
-      eslint-plugin-etc: 2.0.3(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-etc: 2.0.3(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-ext: 0.1.0
-      eslint-plugin-functional: 6.6.3(eslint@10.8.0)(typescript@6.0.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
-      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-functional: 6.6.3(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
+      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-jest-dom: 5.5.0(eslint@10.8.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.8.0)
-      eslint-plugin-n: 17.24.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-n: 17.24.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-no-constructor-bind: 2.0.4
-      eslint-plugin-no-explicit-type-exports: 0.12.1(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-no-explicit-type-exports: 0.12.1(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
       eslint-plugin-no-only-tests: 3.4.0
       eslint-plugin-no-unsanitized: 4.1.5(eslint@10.8.0)
       eslint-plugin-no-use-extend-native: 0.5.0
-      eslint-plugin-perfectionist: 4.15.1(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-perfectionist: 4.15.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-promise: 7.3.0(eslint@10.8.0)
-      eslint-plugin-putout: 22.10.0(eslint@10.8.0)(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      eslint-plugin-putout: 22.10.0(eslint@10.8.0)(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       eslint-plugin-react: 7.37.5(eslint@10.8.0)
-      eslint-plugin-react-form-fields: 1.2.22(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-react-form-fields: 1.2.22(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-react-hook-form: 0.3.1
       eslint-plugin-react-hooks: 5.2.0(eslint@10.8.0)
       eslint-plugin-react-perf: 3.3.3(eslint@10.8.0)
@@ -11230,23 +11316,23 @@ snapshots:
       eslint-plugin-sonarjs: 3.0.7(eslint@10.8.0)
       eslint-plugin-sort-class-members: 1.22.1(eslint@10.8.0)
       eslint-plugin-ssr-friendly: 1.3.0(eslint@10.8.0)
-      eslint-plugin-storybook: 0.12.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-storybook: 0.12.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-styled-components-a11y: 2.2.1(eslint@10.8.0)
-      eslint-plugin-testing-library: 7.16.2(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-testing-library: 7.16.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-toml: 0.12.0(eslint@10.8.0)
-      eslint-plugin-total-functions: 7.1.0(eslint@10.8.0)(typescript@6.0.3)
-      eslint-plugin-typescript-compat: 1.0.2(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-total-functions: 7.1.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      eslint-plugin-typescript-compat: 1.0.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-unicorn: 56.0.1(eslint@10.8.0)
-      eslint-plugin-unused-imports: 3.2.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
+      eslint-plugin-unused-imports: 3.2.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
       eslint-plugin-validate-jsx-nesting: 0.1.1(eslint@10.8.0)
       eslint-plugin-vue: 9.33.0(eslint@10.8.0)
       eslint-plugin-vue-scoped-css: 2.12.0(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0))
       eslint-plugin-vuejs-accessibility: 2.5.0(eslint@10.8.0)(globals@17.7.0)
       eslint-plugin-yml: 1.19.1(eslint@10.8.0)
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
-      typescript-eslint: 7.18.0(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      typescript-eslint: 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/eslint-parser'
@@ -11263,20 +11349,20 @@ snapshots:
       - supports-color
       - vue-eslint-parser
 
-  eslint-config-next@16.2.11(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0)(typescript@6.0.3):
+  eslint-config-next@16.2.11(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint@10.8.0):
     dependencies:
       '@next/eslint-plugin-next': 16.2.11
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.8.0)
       eslint-plugin-react: 7.37.5(eslint@10.8.0)
       eslint-plugin-react-hooks: 7.1.1(eslint@10.8.0)
       globals: 16.4.0
-      typescript-eslint: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      typescript-eslint: 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
@@ -11296,28 +11382,28 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.8.0)
       eslint: 10.8.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0)(eslint-plugin-n@18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3))(eslint-plugin-promise@7.3.0(eslint@10.8.0))(eslint@10.8.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.32.0)(eslint-plugin-n@18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2)))(eslint-plugin-promise@7.3.0(eslint@10.8.0))(eslint@10.8.0):
     dependencies:
       eslint: 10.8.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
-      eslint-plugin-n: 18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
+      eslint-plugin-n: 18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))
       eslint-plugin-promise: 7.3.0(eslint@10.8.0)
 
-  eslint-config-wikimedia@0.32.4(eslint@10.8.0)(typescript@6.0.3):
+  eslint-config-wikimedia@0.32.4(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@stylistic/eslint-plugin': 3.1.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.54.0(eslint@10.8.0)(typescript@6.0.3)
+      '@stylistic/eslint-plugin': 3.1.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       browserslist-config-wikimedia: 0.7.0
       eslint: 10.8.0
       eslint-plugin-compat: 6.2.1(eslint@10.8.0)
       eslint-plugin-es-x: 8.7.0(eslint@10.8.0)
-      eslint-plugin-jest: 29.16.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-jest: 29.16.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-jsdoc: 62.9.0(eslint@10.8.0)
       eslint-plugin-json-es: 1.6.0(eslint@10.8.0)
       eslint-plugin-mediawiki: 0.8.3(eslint@10.8.0)
       eslint-plugin-mocha: 10.5.0(eslint@10.8.0)
-      eslint-plugin-n: 17.24.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint-plugin-n: 17.24.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-no-jquery: 4.0.0(eslint@10.8.0)
       eslint-plugin-qunit: 8.2.6(eslint@10.8.0)
       eslint-plugin-security: 4.0.1
@@ -11330,7 +11416,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-config-xo@0.58.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0)(eslint@10.8.0)(prettier@3.9.6)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3):
+  eslint-config-xo@0.58.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-import-resolver-node@0.3.10)(eslint-plugin-import@2.32.0)(eslint@10.8.0)(prettier@3.9.6)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2)):
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.8.0)
       '@eslint/compat': 2.1.0(eslint@10.8.0)
@@ -11342,21 +11428,21 @@ snapshots:
       confusing-browser-globals: 1.0.11
       eslint: 10.8.0
       eslint-config-prettier: 10.1.8(eslint@10.8.0)
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
       eslint-node-test: 0.3.0(eslint@10.8.0)
       eslint-package-json: 0.2.0(eslint@10.8.0)
       eslint-plugin-ava: 17.0.1(eslint@10.8.0)
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
       eslint-plugin-jsdoc: 63.2.2(eslint@10.8.0)
-      eslint-plugin-n: 18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
+      eslint-plugin-n: 18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2))
       eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0))(eslint@10.8.0)(prettier@3.9.6)
       eslint-plugin-regexp: 3.1.1(eslint@10.8.0)
       eslint-plugin-unicorn: 72.0.0(eslint@10.8.0)
       globals: 17.7.0
-      typescript-eslint: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      typescript-eslint: 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     optionalDependencies:
       prettier: 3.9.6
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - '@types/eslint'
       - '@typescript-eslint/utils'
@@ -11365,13 +11451,13 @@ snapshots:
       - supports-color
       - ts-declaration-location
 
-  eslint-etc@5.2.1(eslint@10.8.0)(typescript@6.0.3):
+  eslint-etc@5.2.1(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/experimental-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
-      tsutils: 3.21.0(typescript@6.0.3)
-      tsutils-etc: 1.4.2(tsutils@3.21.0(typescript@6.0.3))(typescript@6.0.3)
-      typescript: 6.0.3
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
+      tsutils-etc: 1.4.2(@typescript/typescript6@6.0.2)(tsutils@3.21.0(@typescript/typescript6@6.0.2))
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -11389,7 +11475,7 @@ snapshots:
 
   eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
     dependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
 
   eslint-import-resolver-node@0.3.10:
     dependencies:
@@ -11399,7 +11485,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11410,12 +11496,12 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0):
+  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0):
     dependencies:
       debug: 4.4.3
       eslint: 10.8.0
@@ -11426,8 +11512,8 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11441,44 +11527,44 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0))(eslint-plugin-import@2.32.0)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -11519,11 +11605,11 @@ snapshots:
       micro-spelling-correcter: 1.1.1
       resolve-from: 5.0.0
 
-  eslint-plugin-command@3.5.3(@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0):
+  eslint-plugin-command@3.5.3(@typescript-eslint/typescript-estree@8.65.0(@typescript/typescript6@6.0.2))(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0):
     dependencies:
       '@es-joy/jsdoccomment': 0.88.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
 
   eslint-plugin-compat@6.2.1(eslint@10.8.0):
@@ -11576,32 +11662,32 @@ snapshots:
       eslint: 10.8.0
       ignore: 5.3.2
 
-  eslint-plugin-etc@2.0.3(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-etc@2.0.3(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@6.0.3)
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@phenomnomnominal/tsquery': 5.0.1(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/experimental-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
-      eslint-etc: 5.2.1(eslint@10.8.0)(typescript@6.0.3)
+      eslint-etc: 5.2.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       requireindex: 1.2.0
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@6.0.3)
-      typescript: 6.0.3
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   eslint-plugin-ext@0.1.0: {}
 
-  eslint-plugin-functional@6.6.3(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-functional@6.6.3(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/utils': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       deepmerge-ts: 5.1.0
       escape-string-regexp: 4.0.0
       eslint: 10.8.0
-      is-immutable-type: 4.0.0(eslint@10.8.0)(typescript@6.0.3)
+      is-immutable-type: 4.0.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       semver: 7.8.5
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -11609,7 +11695,7 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0):
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0):
     dependencies:
       '@typescript-eslint/types': 8.65.0
       comment-parser: 1.4.7
@@ -11622,12 +11708,12 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.12.2
     optionalDependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11638,7 +11724,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11650,42 +11736,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 10.8.0
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0)
-      hasown: 2.0.4
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.10
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11696,7 +11753,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11708,13 +11765,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11725,7 +11782,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11737,7 +11794,36 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 10.8.0
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
+      hasown: 2.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.10
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11753,33 +11839,33 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@29.16.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-jest@29.16.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      typescript: 6.0.3
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -11880,7 +11966,7 @@ snapshots:
       globals: 13.24.0
       rambda: 7.5.0
 
-  eslint-plugin-n@17.24.0(eslint@10.8.0)(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       enhanced-resolve: 5.24.3
@@ -11891,26 +11977,11 @@ snapshots:
       globrex: 0.1.2
       ignore: 5.3.2
       semver: 7.8.5
-      ts-declaration-location: 1.0.7(typescript@5.9.3)
+      ts-declaration-location: 1.0.7(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-n@17.24.0(eslint@10.8.0)(typescript@6.0.3):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
-      enhanced-resolve: 5.24.3
-      eslint: 10.8.0
-      eslint-plugin-es-x: 7.8.0(eslint@10.8.0)
-      get-tsconfig: 4.14.0
-      globals: 15.15.0
-      globrex: 0.1.2
-      ignore: 5.3.2
-      semver: 7.8.5
-      ts-declaration-location: 1.0.7(typescript@6.0.3)
-    transitivePeerDependencies:
-      - typescript
-
-  eslint-plugin-n@18.2.2(eslint@10.8.0)(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3):
+  eslint-plugin-n@18.2.2(@typescript/typescript6@6.0.2)(eslint@10.8.0)(ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       enhanced-resolve: 5.24.3
@@ -11922,20 +11993,20 @@ snapshots:
       ignore: 5.3.2
       semver: 7.8.5
     optionalDependencies:
-      ts-declaration-location: 1.0.7(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-declaration-location: 1.0.7(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
 
   eslint-plugin-no-constructor-bind@2.0.4:
     dependencies:
       requireindex: 1.2.0
 
-  eslint-plugin-no-explicit-type-exports@0.12.1(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-no-explicit-type-exports@0.12.1(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/experimental-utils': 2.34.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@10.8.0)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11969,19 +12040,19 @@ snapshots:
       resolve: 1.22.12
       semver: 6.3.1
 
-  eslint-plugin-perfectionist@4.15.1(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-perfectionist@4.15.1(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-perfectionist@5.10.0(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-perfectionist@5.10.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -12026,7 +12097,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       eslint: 10.8.0
 
-  eslint-plugin-putout@22.10.0(eslint@10.8.0)(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3)):
+  eslint-plugin-putout@22.10.0(eslint@10.8.0)(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)):
     dependencies:
       '@babel/core': 8.0.1
       '@babel/eslint-parser': 8.0.1(@babel/core@8.0.1)(eslint@10.8.0)
@@ -12035,19 +12106,19 @@ snapshots:
       '@putout/eslint': 3.9.0(eslint@10.8.0)
       '@putout/eslint-config': 9.5.0(eslint@10.8.0)
       '@stylistic/eslint-plugin-jsx': 2.13.0(eslint@10.8.0)
-      '@stylistic/eslint-plugin-ts': 2.13.0(eslint@10.8.0)(typescript@5.9.3)
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@5.9.3))(eslint@10.8.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@5.9.3)
+      '@stylistic/eslint-plugin-ts': 2.13.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       align-spaces: 1.0.4
       eslint: 10.8.0
-      eslint-plugin-n: 17.24.0(eslint@10.8.0)(typescript@5.9.3)
+      eslint-plugin-n: 17.24.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint-plugin-react: 7.37.5(eslint@10.8.0)
       parse-import-specifiers: 1.0.3
-      putout: 35.37.1(eslint@10.8.0)(typescript@6.0.3)
+      putout: 35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       synckit: 0.9.3
       try-catch: 3.0.1
       try-to-catch: 3.0.1
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -12057,9 +12128,9 @@ snapshots:
       eslint: 10.8.0
       requireindex: 1.2.0
 
-  eslint-plugin-react-form-fields@1.2.22(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-react-form-fields@1.2.22(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/experimental-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       jsx-ast-utils: 3.3.5
     transitivePeerDependencies:
@@ -12190,7 +12261,7 @@ snapshots:
       minimatch: 10.1.2
       scslre: 0.3.0
       semver: 7.7.4
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   eslint-plugin-sort-class-members@1.22.1(eslint@10.8.0):
     dependencies:
@@ -12201,10 +12272,10 @@ snapshots:
       eslint: 10.8.0
       globals: 13.24.0
 
-  eslint-plugin-storybook@0.12.0(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-storybook@0.12.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@storybook/csf': 0.1.13
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
       ts-dedent: 2.3.0
     transitivePeerDependencies:
@@ -12217,10 +12288,10 @@ snapshots:
       eslint: 10.8.0
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.8.0)
 
-  eslint-plugin-testing-library@7.16.2(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-testing-library@7.16.2(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     transitivePeerDependencies:
       - supports-color
@@ -12247,26 +12318,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-total-functions@7.1.0(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-total-functions@7.1.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/type-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/type-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
-      is-immutable-type: 1.2.9(eslint@10.8.0)(typescript@6.0.3)
-      tsutils: 3.21.0(typescript@6.0.3)
-      typescript: 6.0.3
+      is-immutable-type: 1.2.9(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-typescript-compat@1.0.2(eslint@10.8.0)(typescript@6.0.3):
+  eslint-plugin-typescript-compat@1.0.2(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@mdn/browser-compat-data': 5.7.6
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/experimental-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       browserslist: 4.28.7
       semver: 7.8.5
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -12337,18 +12408,18 @@ snapshots:
       strip-indent: 4.1.1
       yaml: 2.9.0
 
-  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0):
+  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0):
     dependencies:
       eslint: 10.8.0
       eslint-rule-composer: 0.3.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0):
     dependencies:
       eslint: 10.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
   eslint-plugin-validate-jsx-nesting@0.1.1(eslint@10.8.0):
     dependencies:
@@ -12370,7 +12441,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)):
+  eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0))(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(eslint@10.8.0)(vue-eslint-parser@10.4.1(eslint@10.8.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       eslint: 10.8.0
@@ -12382,7 +12453,7 @@ snapshots:
       xml-name-validator: 5.0.0
     optionalDependencies:
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.0)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
 
   eslint-plugin-vue@9.33.0(eslint@10.8.0):
     dependencies:
@@ -12432,9 +12503,9 @@ snapshots:
       natural-compare: 1.4.0
       yaml-eslint-parser: 2.1.0
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.34)(eslint@10.8.0):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.40)(eslint@10.8.0):
     dependencies:
-      '@vue/compiler-sfc': 3.5.34
+      '@vue/compiler-sfc': 3.5.40
       eslint: 10.8.0
 
   eslint-rule-composer@0.3.0: {}
@@ -12722,9 +12793,9 @@ snapshots:
       flatted: 3.4.3
       hookified: 1.15.1
 
-  flatlint@2.14.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3)):
+  flatlint@2.14.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)):
     dependencies:
-      '@putout/engine-loader': 15.4.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 15.4.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-keyword': 2.2.0
       debug: 4.4.3
       js-tokens: 9.0.1
@@ -12732,9 +12803,9 @@ snapshots:
       - putout
       - supports-color
 
-  flatlint@2.14.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3)):
+  flatlint@2.14.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)):
     dependencies:
-      '@putout/engine-loader': 15.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 15.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-keyword': 2.2.0
       debug: 4.4.3
       js-tokens: 9.0.1
@@ -12876,17 +12947,17 @@ snapshots:
 
   globrex@0.1.2: {}
 
-  goldstein@5.27.0(eslint@10.8.0)(typescript@6.0.3):
+  goldstein@5.27.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@putout/plugin-declare': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-logical-expressions': 7.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-try-catch': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/plugin-declare': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-logical-expressions': 7.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-try-catch': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/printer': 13.4.1
       acorn: 8.17.0
       acorn-typescript: 1.4.13(acorn@8.17.0)
       estree-to-babel: 10.5.0
       estree-util-attach-comments: 3.0.0
-      putout: 38.5.7(eslint@10.8.0)(typescript@6.0.3)
+      putout: 38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
     transitivePeerDependencies:
       - eslint
@@ -13079,21 +13150,21 @@ snapshots:
       identifier-regex: 1.1.0
       super-regex: 1.1.0
 
-  is-immutable-type@1.2.9(eslint@10.8.0)(typescript@6.0.3):
+  is-immutable-type@1.2.9(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/type-utils': 5.62.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  is-immutable-type@4.0.0(eslint@10.8.0)(typescript@6.0.3):
+  is-immutable-type@4.0.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/type-utils': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
-      ts-api-utils: 1.4.3(typescript@6.0.3)
-      ts-declaration-location: 1.0.7(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 1.4.3(@typescript/typescript6@6.0.2)
+      ts-declaration-location: 1.0.7(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -13769,16 +13840,16 @@ snapshots:
 
   nessy@5.3.0: {}
 
-  next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.11(@babel/core@8.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.1
       caniuse-lite: 1.0.30001806
       postcss: 8.4.31
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@8.0.1)(react@19.2.6)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@8.0.1)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.11
       '@next/swc-darwin-x64': 16.2.11
@@ -14168,146 +14239,146 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  putout@35.37.1(eslint@10.8.0)(typescript@6.0.3):
+  putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@putout/babel': 2.10.2
       '@putout/cli-cache': 3.2.0
-      '@putout/cli-choose-formatter': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/cli-choose-formatter': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/cli-keypress': 2.0.0
       '@putout/cli-match': 2.2.1
       '@putout/cli-ruler': 3.1.0
       '@putout/cli-staged': 1.1.0
       '@putout/cli-validate-args': 1.1.1
       '@putout/compare': 14.7.2
-      '@putout/engine-loader': 13.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 13.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/engine-parser': 10.8.0
-      '@putout/engine-processor': 11.4.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/engine-reporter': 1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/engine-runner': 21.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-processor': 11.4.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/engine-reporter': 1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/engine-runner': 21.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/eslint': 3.9.0(eslint@10.8.0)
-      '@putout/formatter-codeframe': 7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-dump': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-frame': 6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-json': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-json-lines': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-memory': 4.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-progress': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-progress-bar': 4.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-stream': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-time': 3.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/formatter-codeframe': 7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-dump': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-frame': 6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-json': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-json-lines': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-memory': 4.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-progress': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-progress-bar': 4.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-stream': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-time': 3.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operate': 12.18.0
-      '@putout/operator-add-args': 8.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-declare': 9.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-add-args': 8.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-declare': 9.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-filesystem': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-ignore': 1.3.0
       '@putout/operator-json': 2.2.0
-      '@putout/operator-match-files': 3.5.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-regexp': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-rename-files': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-at': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-destructuring': 7.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-dot-notation': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-early-return': 3.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-flat-map': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-optional-chaining': 6.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-overrides': 1.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-starts-with': 1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-template-literals': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-browserlist': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-conditions': 4.4.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-apply-to-spread': 4.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-arguments-to-rest': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-array-copy-to-slice': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-assignment-to-arrow-function': 1.2.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-assignment-to-comparison': 2.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-assignment-to-declaration': 1.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-concat-to-flat': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-const-to-let': 2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-index-of-to-includes': 2.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-label-to-object': 1.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-object-assign-to-merge-spread': 6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-object-entries-to-array-entries': 3.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-optional-to-logical': 3.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-quotes-to-backticks': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-template-to-string': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-to-arrow-function': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-coverage': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-declare': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-declare-before-reference': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-declare-imports-first': 2.1.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-eslint': 8.13.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-extract-object-properties': 9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-extract-sequence-expressions': 3.5.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-filesystem': 5.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-for-of': 6.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-generators': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-github': 12.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-gitignore': 6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-group-imports-by-source': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-logical-expressions': 6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-madrun': 18.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-math': 2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-maybe': 2.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-merge-destructuring-properties': 9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-merge-duplicate-functions': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-merge-duplicate-imports': 11.0.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-montag': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-new': 3.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-nodejs': 11.11.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-npmignore': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-package-json': 7.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-promises': 15.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-putout': 20.10.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-putout-config': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-regexp': 9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-console': 6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-constant-conditions': 4.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-debugger': 7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-duplicate-case': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-duplicate-keys': 5.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-empty': 12.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-iife': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-nested-blocks': 6.3.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-quotes-from-import-assertions': 1.0.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unreachable-code': 1.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unreferenced-variables': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-expressions': 9.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-for-of-variables': 3.0.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-private-fields': 2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-variables': 9.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-arguments': 8.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-array': 1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-array-constructor': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-array-entries': 1.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-assign': 1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-constructor': 1.0.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-continue': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-escape': 6.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-functions': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-map': 1.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-operand': 2.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-replace': 1.0.4(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-return': 7.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-spread': 11.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-template-expressions': 2.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-variables': 11.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-reuse-duplicate-init': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-simplify-assignment': 3.1.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-simplify-boolean-return': 2.0.2(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-simplify-ternary': 7.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-sort-imports-by-specifiers': 1.1.3(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-assignment-expressions': 1.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-nested-destructuring': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-variable-declarations': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-tape': 14.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-try-catch': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-types': 4.1.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-typescript': 7.4.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-webpack': 3.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/processor-css': 9.2.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))(typescript@6.0.3)
-      '@putout/processor-filesystem': 4.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-match-files': 3.5.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-regexp': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-rename-files': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-at': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-destructuring': 7.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-dot-notation': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-early-return': 3.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-flat-map': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-optional-chaining': 6.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-overrides': 1.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-starts-with': 1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-template-literals': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-browserlist': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-conditions': 4.4.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-apply-to-spread': 4.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-arguments-to-rest': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-array-copy-to-slice': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-assignment-to-arrow-function': 1.2.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-assignment-to-comparison': 2.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-assignment-to-declaration': 1.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-concat-to-flat': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-const-to-let': 2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-index-of-to-includes': 2.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-label-to-object': 1.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-object-assign-to-merge-spread': 6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-object-entries-to-array-entries': 3.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-optional-to-logical': 3.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-quotes-to-backticks': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-template-to-string': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-to-arrow-function': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-coverage': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-declare': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-declare-before-reference': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-declare-imports-first': 2.1.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-eslint': 8.13.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-extract-object-properties': 9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-extract-sequence-expressions': 3.5.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-filesystem': 5.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-for-of': 6.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-generators': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-github': 12.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-gitignore': 6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-group-imports-by-source': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-logical-expressions': 6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-madrun': 18.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-math': 2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-maybe': 2.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-merge-destructuring-properties': 9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-merge-duplicate-functions': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-merge-duplicate-imports': 11.0.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-montag': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-new': 3.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-nodejs': 11.11.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-npmignore': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-package-json': 7.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-promises': 15.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-putout': 20.10.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-putout-config': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-regexp': 9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-console': 6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-constant-conditions': 4.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-debugger': 7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-duplicate-case': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-duplicate-keys': 5.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-empty': 12.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-iife': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-nested-blocks': 6.3.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-quotes-from-import-assertions': 1.0.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unreachable-code': 1.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unreferenced-variables': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-expressions': 9.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-for-of-variables': 3.0.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-private-fields': 2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-variables': 9.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-arguments': 8.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-array': 1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-array-constructor': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-array-entries': 1.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-assign': 1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-constructor': 1.0.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-continue': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-escape': 6.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-functions': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-map': 1.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-operand': 2.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-replace': 1.0.4(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-return': 7.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-spread': 11.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-template-expressions': 2.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-variables': 11.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-reuse-duplicate-init': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-simplify-assignment': 3.1.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-simplify-boolean-return': 2.0.2(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-simplify-ternary': 7.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-sort-imports-by-specifiers': 1.1.3(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-assignment-expressions': 1.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-nested-destructuring': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-variable-declarations': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-tape': 14.2.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-try-catch': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-types': 4.1.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-typescript': 7.4.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-webpack': 3.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/processor-css': 9.2.0(@typescript/typescript6@6.0.2)(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/processor-filesystem': 4.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/processor-ignore': 6.0.1
-      '@putout/processor-javascript': 5.0.0(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/processor-javascript': 5.0.0(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/processor-json': 9.0.0
       '@putout/processor-markdown': 12.2.0
       '@putout/processor-yaml': 8.1.0
@@ -14326,7 +14397,7 @@ snapshots:
       nano-memoize: 3.0.16
       once: 1.4.0
       picomatch: 4.0.5
-      samadhi: 2.15.1(eslint@10.8.0)(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))(typescript@6.0.3)
+      samadhi: 2.15.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       try-catch: 3.0.1
       try-to-catch: 3.0.1
       wraptile: 3.0.0
@@ -14336,150 +14407,150 @@ snapshots:
       - supports-color
       - typescript
 
-  putout@38.5.7(eslint@10.8.0)(typescript@6.0.3):
+  putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
       '@putout/babel': 3.2.0
       '@putout/cli-cache': 5.0.1
-      '@putout/cli-choose-formatter': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/cli-choose-formatter': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/cli-keypress': 2.0.0
       '@putout/cli-match': 2.2.1
-      '@putout/cli-process-file': 2.4.0(eslint@10.8.0)(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/cli-process-file': 2.4.0(eslint@10.8.0)(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/cli-ruler': 3.1.0
       '@putout/cli-staged': 1.1.0
       '@putout/cli-validate-args': 2.0.0
       '@putout/compare': 16.0.3
-      '@putout/engine-loader': 15.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-loader': 15.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/engine-parser': 12.6.0
-      '@putout/engine-processor': 13.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/engine-reporter': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/engine-runner': 23.6.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-codeframe': 8.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-dump': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-frame': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-json': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-json-lines': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-memory': 4.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-progress': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-progress-bar': 4.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-stream': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/formatter-time': 3.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/engine-processor': 13.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/engine-reporter': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/engine-runner': 23.6.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-codeframe': 8.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-dump': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-frame': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-json': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-json-lines': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-memory': 4.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-progress': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-progress-bar': 4.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-stream': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/formatter-time': 3.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operate': 13.5.0
-      '@putout/operator-add-args': 10.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-declare': 11.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-add-args': 10.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-declare': 11.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-filesystem': 6.4.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-ignore': 2.0.0
       '@putout/operator-json': 2.2.0
       '@putout/operator-keyword': 2.2.0
-      '@putout/operator-match-files': 6.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-match-files': 6.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/operator-parens': 1.2.0
-      '@putout/operator-regexp': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/operator-rename-files': 2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-arrow': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-at': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-destructuring': 8.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-dot-notation': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-flat-map': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-overrides': 2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-shorthand-properties': 6.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-starts-with': 1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-apply-template-literals': 4.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-browserlist': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-conditions': 7.3.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-apply-to-spread': 4.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-arguments-to-rest': 3.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-array-copy-to-slice': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-assignment-to-arrow-function': 1.2.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-assignment-to-comparison': 2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-assignment-to-declaration': 2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-concat-to-flat': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-const-to-let': 4.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-expression-to-params': 1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-index-of-to-includes': 2.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-object-assign-to-merge-spread': 6.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-object-entries-to-array-entries': 3.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-quotes-to-backticks': 4.0.3(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-template-to-string': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-convert-to-arrow-function': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-coverage': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-declare': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-declare-before-reference': 6.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-eslint': 12.4.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-esm': 2.3.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-extract-keywords-from-variables': 2.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-extract-object-properties': 9.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-extract-sequence-expressions': 3.5.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-filesystem': 8.3.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-for-of': 8.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-generators': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-github': 14.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-gitignore': 6.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-labels': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-logical-expressions': 7.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-madrun': 20.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-math': 3.4.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-maybe': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-merge-destructuring-properties': 10.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-merge-duplicate-functions': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-montag': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-new': 3.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-nodejs': 14.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-npmignore': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-optional-chaining': 1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-package-json': 9.1.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-parens': 2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-promises': 16.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-putout': 23.16.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-putout-config': 8.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-regexp': 10.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-console': 6.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-constant-conditions': 4.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-debugger': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-duplicate-case': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-duplicate-keys': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-empty': 14.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-iife': 4.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-nested-blocks': 8.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unreachable-code': 2.2.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unreferenced-variables': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-expressions': 11.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-for-of-variables': 3.0.3(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-labels': 1.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-private-fields': 3.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-unused-variables': 12.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-arguments': 11.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-array': 1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-array-constructor': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-array-entries': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-assign': 1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-constructor': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-continue': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-delete': 1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-escape': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-functions': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-map': 1.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-operand': 2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-push': 1.0.3(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-replace': 1.0.4(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-spread': 12.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-template-expressions': 2.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-remove-useless-variables': 13.0.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-return': 1.1.2(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-reuse-duplicate-init': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-simplify-assignment': 3.1.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-simplify-ternary': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-assignment-expressions': 2.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-call-with-destructuring': 1.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-nested-destructuring': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-split-variable-declarations': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-tape': 17.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-try-catch': 4.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-types': 7.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-typescript': 11.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/plugin-webpack': 3.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      '@putout/processor-css': 10.0.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))(typescript@6.0.3)
-      '@putout/processor-filesystem': 5.1.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/operator-regexp': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/operator-rename-files': 2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-arrow': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-at': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-destructuring': 8.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-dot-notation': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-flat-map': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-overrides': 2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-shorthand-properties': 6.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-starts-with': 1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-apply-template-literals': 4.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-browserlist': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-conditions': 7.3.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-apply-to-spread': 4.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-arguments-to-rest': 3.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-array-copy-to-slice': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-assignment-to-arrow-function': 1.2.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-assignment-to-comparison': 2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-assignment-to-declaration': 2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-concat-to-flat': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-const-to-let': 4.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-expression-to-params': 1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-index-of-to-includes': 2.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-object-assign-to-merge-spread': 6.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-object-entries-to-array-entries': 3.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-quotes-to-backticks': 4.0.3(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-template-to-string': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-convert-to-arrow-function': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-coverage': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-declare': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-declare-before-reference': 6.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-eslint': 12.4.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-esm': 2.3.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-extract-keywords-from-variables': 2.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-extract-object-properties': 9.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-extract-sequence-expressions': 3.5.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-filesystem': 8.3.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-for-of': 8.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-generators': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-github': 14.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-gitignore': 6.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-labels': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-logical-expressions': 7.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-madrun': 20.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-math': 3.4.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-maybe': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-merge-destructuring-properties': 10.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-merge-duplicate-functions': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-montag': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-new': 3.0.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-nodejs': 14.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-npmignore': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-optional-chaining': 1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-package-json': 9.1.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-parens': 2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-promises': 16.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-putout': 23.16.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-putout-config': 8.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-regexp': 10.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-console': 6.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-constant-conditions': 4.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-debugger': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-duplicate-case': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-duplicate-keys': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-empty': 14.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-iife': 4.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-nested-blocks': 8.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unreachable-code': 2.2.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unreferenced-variables': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-expressions': 11.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-for-of-variables': 3.0.3(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-labels': 1.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-private-fields': 3.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-unused-variables': 12.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-arguments': 11.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-array': 1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-array-constructor': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-array-entries': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-assign': 1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-constructor': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-continue': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-delete': 1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-escape': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-functions': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-map': 1.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-operand': 2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-push': 1.0.3(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-replace': 1.0.4(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-spread': 12.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-template-expressions': 2.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-remove-useless-variables': 13.0.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-return': 1.1.2(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-reuse-duplicate-init': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-simplify-assignment': 3.1.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-simplify-ternary': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-assignment-expressions': 2.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-call-with-destructuring': 1.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-nested-destructuring': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-split-variable-declarations': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-tape': 17.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-try-catch': 4.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-types': 7.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-typescript': 11.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/plugin-webpack': 3.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/processor-css': 10.0.1(@typescript/typescript6@6.0.2)(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      '@putout/processor-filesystem': 5.1.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/processor-ignore': 6.0.1
-      '@putout/processor-javascript': 5.0.0(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
+      '@putout/processor-javascript': 5.0.0(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
       '@putout/processor-json': 9.0.0
       '@putout/processor-markdown': 12.2.0
       '@putout/processor-yaml': 8.1.0
@@ -14519,14 +14590,14 @@ snapshots:
 
   rambda@7.5.0: {}
 
-  react-dom@19.2.6(react@19.2.6):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.6
+      react: 19.2.8
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
-  react@19.2.6: {}
+  react@19.2.8: {}
 
   read-pkg-up@7.0.1:
     dependencies:
@@ -14850,11 +14921,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  samadhi@2.15.1(eslint@10.8.0)(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))(typescript@6.0.3):
+  samadhi@2.15.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0)):
     dependencies:
       '@putout/quick-lint': 1.6.0
-      flatlint: 2.14.1(putout@35.37.1(eslint@10.8.0)(typescript@6.0.3))
-      goldstein: 5.27.0(eslint@10.8.0)(typescript@6.0.3)
+      flatlint: 2.14.1(putout@35.37.1(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      goldstein: 5.27.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
     transitivePeerDependencies:
       - eslint
@@ -14862,11 +14933,11 @@ snapshots:
       - supports-color
       - typescript
 
-  samadhi@2.15.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3)):
+  samadhi@2.15.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0)):
     dependencies:
       '@putout/quick-lint': 1.6.0
-      flatlint: 2.14.1(putout@38.5.7(eslint@10.8.0)(typescript@6.0.3))
-      goldstein: 5.27.0(eslint@10.8.0)(typescript@6.0.3)
+      flatlint: 2.14.1(putout@38.5.7(@typescript/typescript6@6.0.2)(eslint@10.8.0))
+      goldstein: 5.27.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       try-catch: 3.0.1
     transitivePeerDependencies:
       - putout
@@ -15120,29 +15191,29 @@ snapshots:
 
   style-search@0.1.0: {}
 
-  styled-jsx@5.1.6(@babel/core@8.0.1)(react@19.2.6):
+  styled-jsx@5.1.6(@babel/core@8.0.1)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.6
+      react: 19.2.8
     optionalDependencies:
       '@babel/core': 8.0.1
 
-  stylelint-config-recommended@15.0.0(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-config-recommended@15.0.0(stylelint@16.26.1(@typescript/typescript6@6.0.2)):
     dependencies:
-      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint: 16.26.1(@typescript/typescript6@6.0.2)
 
-  stylelint-config-standard@37.0.0(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-config-standard@37.0.0(stylelint@16.26.1(@typescript/typescript6@6.0.2)):
     dependencies:
-      stylelint: 16.26.1(typescript@6.0.3)
-      stylelint-config-recommended: 15.0.0(stylelint@16.26.1(typescript@6.0.3))
+      stylelint: 16.26.1(@typescript/typescript6@6.0.2)
+      stylelint-config-recommended: 15.0.0(stylelint@16.26.1(@typescript/typescript6@6.0.2))
 
-  stylelint-prettier@5.0.3(prettier@3.9.6)(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-prettier@5.0.3(prettier@3.9.6)(stylelint@16.26.1(@typescript/typescript6@6.0.2)):
     dependencies:
       prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
-      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint: 16.26.1(@typescript/typescript6@6.0.2)
 
-  stylelint@16.26.1(typescript@6.0.3):
+  stylelint@16.26.1(@typescript/typescript6@6.0.2):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
@@ -15152,7 +15223,7 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.2.1
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.2)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
       debug: 4.4.3
@@ -15278,31 +15349,18 @@ snapshots:
 
   try-to-catch@3.0.1: {}
 
-  ts-api-utils@1.4.3(typescript@5.9.3):
+  ts-api-utils@1.4.3(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  ts-api-utils@1.4.3(typescript@6.0.3):
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
-  ts-api-utils@2.5.0(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
-
-  ts-declaration-location@1.0.7(typescript@5.9.3):
+  ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2):
     dependencies:
       picomatch: 4.0.5
-      typescript: 5.9.3
-
-  ts-declaration-location@1.0.7(typescript@6.0.3):
-    dependencies:
-      picomatch: 4.0.5
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   ts-dedent@2.3.0: {}
 
@@ -15317,17 +15375,17 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsutils-etc@1.4.2(tsutils@3.21.0(typescript@6.0.3))(typescript@6.0.3):
+  tsutils-etc@1.4.2(@typescript/typescript6@6.0.2)(tsutils@3.21.0(@typescript/typescript6@6.0.2)):
     dependencies:
       '@types/yargs': 17.0.35
-      tsutils: 3.21.0(typescript@6.0.3)
-      typescript: 6.0.3
+      tsutils: 3.21.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
       yargs: 17.7.3
 
-  tsutils@3.21.0(typescript@6.0.3):
+  tsutils@3.21.0(@typescript/typescript6@6.0.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   tsx@4.23.1:
     dependencies:
@@ -15382,31 +15440,52 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@7.18.0(eslint@10.8.0)(typescript@6.0.3):
+  typescript-eslint@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.65.0(eslint@10.8.0)(typescript@6.0.3):
+  typescript-eslint@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0))(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/parser': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
+      '@typescript-eslint/typescript-estree': 8.65.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.65.0(@typescript/typescript6@6.0.2)(eslint@10.8.0)
       eslint: 10.8.0
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ufo@1.6.4: {}
 


### PR DESCRIPTION
## Summary
This PR updates the TypeScript-related dependencies in the project and introduces pnpm package overrides to ensure consistent TypeScript versions across the dependency tree.

## Key Changes
- Added `@typescript/native` as an alias for TypeScript 7.0.2 in devDependencies
- Updated the main `typescript` dependency to use `@typescript/typescript6@^6.0.2` instead of the standard TypeScript package
- Added a `pnpm.overrides` configuration to enforce the custom TypeScript 6 package across all transitive dependencies

## Notable Details
- The changes introduce a custom TypeScript package namespace (`@typescript/typescript6`) for version 6.x, while also adding a native TypeScript 7.x alias
- The pnpm overrides ensure that any dependency requiring TypeScript will resolve to the specified `@typescript/typescript6@^6.0.2` version, preventing version conflicts in the dependency tree
- This approach allows the project to maintain control over TypeScript versions across the entire dependency graph

https://claude.ai/code/session_01XLVzgfjXHRxKWY8T2ueYwN