### PR TITLE
chore: add eslint8 alias dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/node": "^26.1.1",
     "@typescript/native": "npm:typescript@^7.0.2",
+    "eslint8": "npm:eslint@^8.57.1",
     "oxfmt": "^0.60.0",
     "oxlint": "^1.75.0",
     "oxlint-tsgolint": "^7.0.2001",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
+      eslint8:
+        specifier: npm:eslint@^8.57.1
+        version: eslint@8.57.1
       oxfmt:
         specifier: ^0.60.0
         version: 0.60.0
@@ -7757,6 +7760,11 @@ snapshots:
       eslint: 10.8.0
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/compat@2.1.0(eslint@10.8.0)':
@@ -12595,7 +12603,7 @@ snapshots:
 
   eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1


### PR DESCRIPTION
## Summary

- No oxlint updates were available (already at v1.75.0)
- Ran `pnpm update --latest` — all other packages were already up to date
- Added `eslint8@npm:eslint@8` as a devDependency alias per the update routine

All 183 tests pass via `pnpm before-commit`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bzt2wuCJp7fJk7T4HBzRjU)_