### PR TITLE
Replace extglob patterns with plain globs in oxlint configs

### DIFF
--- a/packages/oxlint-config-presets/configs/@antfu.json
+++ b/packages/oxlint-config-presets/configs/@antfu.json
@@ -255,7 +255,14 @@
   },
   "overrides": [
     {
-      "files": ["**/*.?([cm])[jt]s?(x)"],
+      "files": [
+        "**/*.[jt]s",
+        "**/*.[jt]sx",
+        "**/*.c[jt]s",
+        "**/*.c[jt]sx",
+        "**/*.m[jt]s",
+        "**/*.m[jt]sx"
+      ],
       "rules": {
         "node/handle-callback-err": ["error", "^(err|error)$"],
         "node/no-exports-assign": "error",
@@ -290,7 +297,7 @@
       "plugins": ["node", "jsdoc", "unicorn"]
     },
     {
-      "files": ["**/*.?([cm])ts", "**/*.?([cm])tsx"],
+      "files": ["**/*.ts", "**/*.cts", "**/*.mts", "**/*.tsx", "**/*.ctsx", "**/*.mtsx"],
       "rules": {
         "constructor-super": "off",
         "getter-return": "off",
@@ -325,18 +332,50 @@
     },
     {
       "files": [
-        "**/__tests__/**/*.?([cm])[jt]s?(x)",
-        "**/*.spec.?([cm])[jt]s?(x)",
-        "**/*.test.?([cm])[jt]s?(x)",
-        "**/*.bench.?([cm])[jt]s?(x)",
-        "**/*.benchmark.?([cm])[jt]s?(x)"
+        "**/__tests__/**/*.[jt]s",
+        "**/__tests__/**/*.[jt]sx",
+        "**/__tests__/**/*.c[jt]s",
+        "**/__tests__/**/*.c[jt]sx",
+        "**/__tests__/**/*.m[jt]s",
+        "**/__tests__/**/*.m[jt]sx",
+        "**/*.spec.[jt]s",
+        "**/*.spec.[jt]sx",
+        "**/*.spec.c[jt]s",
+        "**/*.spec.c[jt]sx",
+        "**/*.spec.m[jt]s",
+        "**/*.spec.m[jt]sx",
+        "**/*.test.[jt]s",
+        "**/*.test.[jt]sx",
+        "**/*.test.c[jt]s",
+        "**/*.test.c[jt]sx",
+        "**/*.test.m[jt]s",
+        "**/*.test.m[jt]sx",
+        "**/*.bench.[jt]s",
+        "**/*.bench.[jt]sx",
+        "**/*.bench.c[jt]s",
+        "**/*.bench.c[jt]sx",
+        "**/*.bench.m[jt]s",
+        "**/*.bench.m[jt]sx",
+        "**/*.benchmark.[jt]s",
+        "**/*.benchmark.[jt]sx",
+        "**/*.benchmark.c[jt]s",
+        "**/*.benchmark.c[jt]sx",
+        "**/*.benchmark.m[jt]s",
+        "**/*.benchmark.m[jt]sx"
       ],
       "rules": {
         "no-unused-expressions": "off"
       }
     },
     {
-      "files": ["**/*.md/**/*.?([cm])[jt]s?(x)"],
+      "files": [
+        "**/*.md/**/*.[jt]s",
+        "**/*.md/**/*.[jt]sx",
+        "**/*.md/**/*.c[jt]s",
+        "**/*.md/**/*.c[jt]sx",
+        "**/*.md/**/*.m[jt]s",
+        "**/*.md/**/*.m[jt]sx"
+      ],
       "rules": {
         "no-alert": "off",
         "no-console": "off",
@@ -351,11 +390,36 @@
     },
     {
       "files": [
-        "**/scripts/**/*.?([cm])[jt]s?(x)",
-        "**/cli/**/*.?([cm])[jt]s?(x)",
-        "**/cli.?([cm])[jt]s?(x)",
-        "**/*.config.?([cm])[jt]s?(x)",
-        "**/*.config.*.?([cm])[jt]s?(x)"
+        "**/scripts/**/*.[jt]s",
+        "**/scripts/**/*.[jt]sx",
+        "**/scripts/**/*.c[jt]s",
+        "**/scripts/**/*.c[jt]sx",
+        "**/scripts/**/*.m[jt]s",
+        "**/scripts/**/*.m[jt]sx",
+        "**/cli/**/*.[jt]s",
+        "**/cli/**/*.[jt]sx",
+        "**/cli/**/*.c[jt]s",
+        "**/cli/**/*.c[jt]sx",
+        "**/cli/**/*.m[jt]s",
+        "**/cli/**/*.m[jt]sx",
+        "**/cli.[jt]s",
+        "**/cli.[jt]sx",
+        "**/cli.c[jt]s",
+        "**/cli.c[jt]sx",
+        "**/cli.m[jt]s",
+        "**/cli.m[jt]sx",
+        "**/*.config.[jt]s",
+        "**/*.config.[jt]sx",
+        "**/*.config.c[jt]s",
+        "**/*.config.c[jt]sx",
+        "**/*.config.m[jt]s",
+        "**/*.config.m[jt]sx",
+        "**/*.config.*.[jt]s",
+        "**/*.config.*.[jt]sx",
+        "**/*.config.*.c[jt]s",
+        "**/*.config.*.c[jt]sx",
+        "**/*.config.*.m[jt]s",
+        "**/*.config.*.m[jt]sx"
       ],
       "rules": {
         "no-console": "off"

--- a/packages/oxlint-config-presets/scripts/generate.ts
+++ b/packages/oxlint-config-presets/scripts/generate.ts
@@ -20,6 +20,7 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import migrate, { type default as Migrate } from '@oxlint/migrate';
+import { expandExtglob } from './glob-utils.js';
 
 type OxlintConfig = Awaited<ReturnType<typeof Migrate>>;
 
@@ -744,6 +745,36 @@ interface GenerateResult {
   warnings: string[];
 }
 
+// Patterns that use extglob syntax with no finite plain-glob equivalent
+// (`*(...)`, `+(...)`, `!(...)`) and so can't be auto-expanded by
+// expandExtglob. Add a manually verified plain-glob replacement here if one
+// of these ever shows up in a source config; expandGlobPattern() below
+// throws instead of silently dropping the pattern so this can't go unnoticed.
+const MANUAL_GLOB_REWRITES: Record<string, string[]> = {};
+
+/**
+ * Rewrites a single `overrides[].files` pattern into one or more plain-glob
+ * patterns with no extglob syntax, since fast-glob (used by oxlint's file
+ * matcher) doesn't support it and silently ignores such patterns instead of
+ * erroring: https://github.com/oxc-project/oxc/issues/21525
+ */
+function expandGlobPattern(pattern: string): string[] {
+  const manual = MANUAL_GLOB_REWRITES[pattern];
+  if (manual) return manual;
+
+  const expanded = expandExtglob(pattern);
+  if (expanded === null) {
+    throw new Error(
+      `overrides[].files pattern "${pattern}" uses extglob syntax with no finite plain-glob ` +
+        `equivalent (a "*(...)", "+(...)", or "!(...)" group, or a nested group). fast-glob ` +
+        `(used by oxlint) does not support extglob and would silently ignore this pattern: ` +
+        `https://github.com/oxc-project/oxc/issues/21525. Add a manually verified replacement ` +
+        `to MANUAL_GLOB_REWRITES in generate.ts.`,
+    );
+  }
+  return expanded;
+}
+
 function sanitizeOxlintConfig(config: OxlintConfig): void {
   if (Array.isArray(config.overrides)) {
     config.overrides = config.overrides
@@ -751,9 +782,10 @@ function sanitizeOxlintConfig(config: OxlintConfig): void {
         delete override.globals;
 
         if (Array.isArray(override.files)) {
-          override.files = override.files.filter(
+          const stringPatterns = override.files.filter(
             (pattern): pattern is string => typeof pattern === 'string',
           );
+          override.files = [...new Set(stringPatterns.flatMap(expandGlobPattern))];
         }
         return override;
       })

--- a/packages/oxlint-config-presets/scripts/generate.ts
+++ b/packages/oxlint-config-presets/scripts/generate.ts
@@ -745,13 +745,6 @@ interface GenerateResult {
   warnings: string[];
 }
 
-// Patterns that use extglob syntax with no finite plain-glob equivalent
-// (`*(...)`, `+(...)`, `!(...)`) and so can't be auto-expanded by
-// expandExtglob. Add a manually verified plain-glob replacement here if one
-// of these ever shows up in a source config; expandGlobPattern() below
-// throws instead of silently dropping the pattern so this can't go unnoticed.
-const MANUAL_GLOB_REWRITES: Record<string, string[]> = {};
-
 /**
  * Rewrites a single `overrides[].files` pattern into one or more plain-glob
  * patterns with no extglob syntax, since fast-glob (used by oxlint's file
@@ -759,17 +752,14 @@ const MANUAL_GLOB_REWRITES: Record<string, string[]> = {};
  * erroring: https://github.com/oxc-project/oxc/issues/21525
  */
 function expandGlobPattern(pattern: string): string[] {
-  const manual = MANUAL_GLOB_REWRITES[pattern];
-  if (manual) return manual;
-
   const expanded = expandExtglob(pattern);
   if (expanded === null) {
     throw new Error(
       `overrides[].files pattern "${pattern}" uses extglob syntax with no finite plain-glob ` +
         `equivalent (a "*(...)", "+(...)", or "!(...)" group, or a nested group). fast-glob ` +
         `(used by oxlint) does not support extglob and would silently ignore this pattern: ` +
-        `https://github.com/oxc-project/oxc/issues/21525. Add a manually verified replacement ` +
-        `to MANUAL_GLOB_REWRITES in generate.ts.`,
+        `https://github.com/oxc-project/oxc/issues/21525. Add a manually verified plain-glob ` +
+        `replacement for it here in generate.ts.`,
     );
   }
   return expanded;

--- a/packages/oxlint-config-presets/scripts/glob-utils.ts
+++ b/packages/oxlint-config-presets/scripts/glob-utils.ts
@@ -1,0 +1,148 @@
+/**
+ * fast-glob (used by oxlint's `overrides[].files` matcher) does not support
+ * extglob syntax (`@(...)`, `?(...)`, `*(...)`, `+(...)`, `!(...)`), unlike
+ * ESLint's minimatch-based file matching. Patterns using it are silently
+ * ignored rather than rejected: https://github.com/oxc-project/oxc/issues/21525
+ *
+ * `@(...)` and `?(...)` enumerate a finite set of alternatives, so they can
+ * be rewritten into plain glob patterns with the same matching behavior.
+ * `*(...)`, `+(...)`, and `!(...)` have no finite plain-glob equivalent
+ * (unbounded repetition / negation) per the oxc maintainers' own analysis on
+ * that issue, so callers must supply a manual replacement for those instead.
+ */
+
+interface ExtglobToken {
+  index: number;
+  length: number;
+  operator: '@' | '?' | '*' | '+' | '!';
+  content: string;
+}
+
+/** Finds top-level (non-nested) extglob tokens. Returns null if a token appears to be nested. */
+function findExtglobTokens(pattern: string): ExtglobToken[] | null {
+  const tokens: ExtglobToken[] = [];
+  const re = /([@?*+!])\(([^()]*)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(pattern))) {
+    tokens.push({
+      index: match.index,
+      length: match[0].length,
+      operator: match[1] as ExtglobToken['operator'],
+      content: match[2],
+    });
+  }
+
+  let stripped = pattern;
+  for (const token of [...tokens].sort((a, b) => b.index - a.index)) {
+    stripped = stripped.slice(0, token.index) + stripped.slice(token.index + token.length);
+  }
+  // An operator immediately followed by '(' still present means a token was
+  // nested (or otherwise malformed) and wasn't captured above - bail rather
+  // than risk misinterpreting the pattern.
+  if (/[@?*+!]\(/.test(stripped)) return null;
+
+  return tokens;
+}
+
+function splitTopLevel(input: string, separator: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of input) {
+    if (ch === '[') depth++;
+    else if (ch === ']') depth = Math.max(0, depth - 1);
+
+    if (ch === separator && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Expands a `[...]` bracket expression (chars and/or `a-z` ranges) into individual characters. */
+function expandBracketClass(expr: string): string[] | null {
+  const chars: string[] = [];
+  for (let i = 0; i < expr.length; i++) {
+    if (expr[i + 1] === '-' && expr[i + 2] !== undefined) {
+      const start = expr.charCodeAt(i);
+      const end = expr.charCodeAt(i + 2);
+      if (end < start) return null;
+      for (let code = start; code <= end; code++) chars.push(String.fromCharCode(code));
+      i += 2;
+    } else {
+      chars.push(expr[i]);
+    }
+  }
+  return chars;
+}
+
+function expandAlternative(alt: string): string[] | null {
+  const bracketMatch = /^\[([^\]]+)\]$/.exec(alt);
+  if (bracketMatch) return expandBracketClass(bracketMatch[1]);
+  // A literal alternative that still contains glob metacharacters (other
+  // than plain `*`/`?`) is out of scope for this simple expander.
+  if (/[[\]]/.test(alt)) return null;
+  return [alt];
+}
+
+function expandTokenContent(content: string): string[] | null {
+  const alternatives: string[] = [];
+  for (const part of splitTopLevel(content, '|')) {
+    const expanded = expandAlternative(part);
+    if (!expanded) return null;
+    alternatives.push(...expanded);
+  }
+  return alternatives;
+}
+
+function expandToken(token: ExtglobToken): string[] | null {
+  const alternatives = expandTokenContent(token.content);
+  if (!alternatives) return null;
+
+  switch (token.operator) {
+    case '@': // exactly one of the alternatives
+      return alternatives;
+    case '?': // zero or one
+      return ['', ...alternatives];
+    case '*': // zero or more - unbounded, no finite plain-glob equivalent
+    case '+': // one or more - unbounded, no finite plain-glob equivalent
+    case '!': // negation - no plain-glob equivalent
+      return null;
+  }
+}
+
+/**
+ * Expands `@(...)` / `?(...)` extglob tokens in `pattern` into an equivalent
+ * set of plain glob patterns with no extglob syntax. Returns `[pattern]`
+ * unchanged if it contains no extglob syntax, or `null` if it contains
+ * extglob syntax that has no finite plain-glob equivalent (`*(...)`,
+ * `+(...)`, `!(...)`, or a token nested inside another).
+ */
+export function expandExtglob(pattern: string): string[] | null {
+  const tokens = findExtglobTokens(pattern);
+  if (tokens === null) return null;
+  if (tokens.length === 0) return [pattern];
+
+  let results = [''];
+  let cursor = 0;
+  for (const token of tokens) {
+    const literal = pattern.slice(cursor, token.index);
+    const alternatives = expandToken(token);
+    if (!alternatives) return null;
+    results = results.flatMap((prefix) => alternatives.map((alt) => prefix + literal + alt));
+    cursor = token.index + token.length;
+  }
+  const tail = pattern.slice(cursor);
+  results = results.map((r) => r + tail);
+
+  return [...new Set(results)];
+}
+
+/** True if `pattern` contains extglob syntax fast-glob does not support. */
+export function hasExtglob(pattern: string): boolean {
+  return /[@?*+!]\([^)]*\)/.test(pattern);
+}

--- a/packages/oxlint-config-presets/tests/glob-utils.test.ts
+++ b/packages/oxlint-config-presets/tests/glob-utils.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { globSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { expandExtglob, hasExtglob } from '../scripts/glob-utils.js';
+
+const rootDir = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+test('expandExtglob leaves plain patterns untouched', () => {
+  assert.deepEqual(expandExtglob('**/*.ts'), ['**/*.ts']);
+  assert.deepEqual(expandExtglob('**/*.[jt]s'), ['**/*.[jt]s']);
+});
+
+test('expandExtglob expands ?(...) around a bracket class', () => {
+  const result = expandExtglob('**/*.?([cm])ts');
+  assert.deepEqual(new Set(result), new Set(['**/*.ts', '**/*.cts', '**/*.mts']));
+});
+
+test('expandExtglob expands multiple ?(...) tokens (cartesian product)', () => {
+  const result = expandExtglob('**/*.?([cm])[jt]s?(x)');
+  assert.deepEqual(
+    new Set(result),
+    new Set([
+      '**/*.[jt]s',
+      '**/*.[jt]sx',
+      '**/*.c[jt]s',
+      '**/*.c[jt]sx',
+      '**/*.m[jt]s',
+      '**/*.m[jt]sx',
+    ]),
+  );
+});
+
+test('expandExtglob expands @(...) alternation without an empty option', () => {
+  const result = expandExtglob('**/*.stories.@(ts|tsx|js|jsx)');
+  assert.deepEqual(
+    new Set(result),
+    new Set(['**/*.stories.ts', '**/*.stories.tsx', '**/*.stories.js', '**/*.stories.jsx']),
+  );
+});
+
+test('expandExtglob returns null for unbounded extglob operators', () => {
+  assert.equal(expandExtglob('**/*.*(foo)'), null);
+  assert.equal(expandExtglob('**/*.+(foo)'), null);
+  assert.equal(expandExtglob('**/!(foo).ts'), null);
+});
+
+test('hasExtglob detects extglob operators', () => {
+  assert.equal(hasExtglob('**/*.?([cm])ts'), true);
+  assert.equal(hasExtglob('**/*.@(ts|tsx)'), true);
+  assert.equal(hasExtglob('**/*.[jt]s'), false);
+  assert.equal(hasExtglob('**/*.ts'), false);
+});
+
+// Regression guard: fast-glob (used by oxlint's overrides[].files matcher)
+// silently ignores extglob patterns instead of erroring, so a pattern that
+// slips through here would fail with no diagnostic at all:
+// https://github.com/oxc-project/oxc/issues/21525
+test('no generated config contains extglob syntax in overrides[].files', () => {
+  const configFiles = globSync('configs/**/*.json', { cwd: rootDir });
+  assert.ok(configFiles.length > 0, 'No config files found under configs/');
+
+  interface OxlintConfig {
+    overrides?: Array<{ files?: unknown }>;
+  }
+
+  const offenders: string[] = [];
+
+  for (const configFile of configFiles) {
+    const config = JSON.parse(readFileSync(join(rootDir, configFile), 'utf-8')) as OxlintConfig;
+    for (const override of config.overrides ?? []) {
+      if (!Array.isArray(override.files)) continue;
+      for (const pattern of override.files) {
+        if (typeof pattern === 'string' && hasExtglob(pattern)) {
+          offenders.push(`${configFile}: ${pattern}`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Found extglob patterns in generated configs:\n${offenders.join('\n')}`,
+  );
+});


### PR DESCRIPTION
## Summary

This PR replaces extglob syntax (`@(...)`, `?(...)`, etc.) in oxlint configuration file patterns with equivalent plain glob patterns. This is necessary because oxlint uses fast-glob for file matching, which doesn't support extglob syntax and silently ignores such patterns instead of erroring.

## Key Changes

- **Added glob utility module** (`glob-utils.ts`): New utility functions to detect and expand extglob patterns:
  - `expandExtglob()`: Converts `@(...)` and `?(...)` patterns into equivalent plain glob patterns; returns `null` for unbounded operators (`*`, `+`, `!`) that have no finite equivalent
  - `hasExtglob()`: Detects presence of extglob syntax in patterns

- **Updated `@antfu` config** (`@antfu.json`): Expanded all extglob patterns in `overrides[].files` to plain glob equivalents:
  - `**/*.?([cm])[jt]s?(x)` → 6 patterns covering all combinations of optional `c`/`m` and `j`/`t` prefixes with optional `x` suffix
  - `**/*.?([cm])ts` → 3 patterns for TypeScript variants
  - Similar expansions for test files, markdown code blocks, and config files

- **Updated config generation** (`generate.ts`): Added automatic pattern expansion during config generation:
  - `expandGlobPattern()` function wraps `expandExtglob()` with error handling
  - Sanitization now expands all extglob patterns and deduplicates results
  - Throws descriptive error if a pattern uses unbounded extglob operators

- **Added comprehensive tests** (`glob-utils.test.ts`): Test suite covering:
  - Plain pattern passthrough
  - `?()` expansion with bracket classes
  - Multiple token expansion (cartesian product)
  - `@()` alternation expansion
  - Rejection of unbounded operators
  - Regression test ensuring no generated configs contain extglob syntax

## Implementation Details

The expansion logic handles:
- Bracket expressions like `[cm]` and `[jt]`
- Character ranges like `a-z`
- Multiple extglob tokens in a single pattern (cartesian product)
- Deduplication of resulting patterns
- Detection of nested/malformed tokens (returns `null` to bail safely)

This ensures oxlint will correctly match all intended files, fixing the silent-ignore issue documented in https://github.com/oxc-project/oxc/issues/21525.

https://claude.ai/code/session_01LYmahB2fg2YhBc9WvAftw5